### PR TITLE
feat: add usePromptEditor prop and fix semantic threshold propagation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-testrunner-components",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-testrunner-components",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.40.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-testrunner-components",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Stencil web component library for LLM test runner functionality",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components/llm-test-runner/header/llm-test-runner-header.tsx
+++ b/src/components/llm-test-runner/header/llm-test-runner-header.tsx
@@ -7,6 +7,7 @@ export interface LLMTestRunnerHeaderProps {
   isRunningAll: boolean;
   useSave?: boolean;
   isSaving?: boolean;
+  usePromptEditor?: boolean;
   onImport: (file: File) => void;
   onExportSuite: () => void;
   onExportResults: () => void;
@@ -22,6 +23,7 @@ export const LLMTestRunnerHeader: FunctionalComponent<
   isRunningAll,
   useSave = false,
   isSaving = false,
+  usePromptEditor = false,
   onImport,
   onExportSuite,
   onExportResults,
@@ -74,9 +76,11 @@ export const LLMTestRunnerHeader: FunctionalComponent<
       </div>
 
       <div class="test-runner-header__right">
-        <Button variant="secondary" size="md" icon="⚙️">
-          Prompt Editor
-        </Button>
+        {usePromptEditor && (
+          <Button variant="secondary" size="md" icon="⚙️">
+            Prompt Editor
+          </Button>
+        )}
         <Button
           variant="secondary"
           size="md"

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -56,6 +56,7 @@ export class LLMTestRunner {
   @Event() save: EventEmitter<SavePayload>;
   @Prop() delayMs?: number = 500;
   @Prop() useSave?: boolean = false;
+  @Prop() usePromptEditor?: boolean = false;
   @Prop() initialTestCases?: TestCase[];
   @Prop() defaultExpectedOutcomeSchema?: ExpectedOutcomeSchema;
   @State() testCases: TestCase[] = [
@@ -327,6 +328,7 @@ export class LLMTestRunner {
           isRunningAll={this.isRunningAll}
           useSave={this.useSave}
           isSaving={this.isSaving}
+          usePromptEditor={this.usePromptEditor}
           onImport={file => this.handleImport(file)}
           onExportSuite={() => this.handleExportTestSuite()}
           onExportResults={() => this.handleExportTestResults()}

--- a/src/lib/evaluation/evaluators/semantic/SemanticEvaluator.ts
+++ b/src/lib/evaluation/evaluators/semantic/SemanticEvaluator.ts
@@ -25,6 +25,9 @@ export class SemanticEvaluator {
   async performEvaluation(
     request: EvaluationRequest,
   ): Promise<EvaluationResult> {
+    const threshold =
+      request.evaluationParameters?.threshold ?? DEFAULT_SEMANTIC_PASS_SCORE;
+
     try {
       await this.initialize();
 
@@ -40,7 +43,7 @@ export class SemanticEvaluator {
         SemanticEvaluator.extractor,
         request.actualResponse,
         expectedKeywords,
-        DEFAULT_SEMANTIC_PASS_SCORE,
+        threshold,
       );
 
       const totalItems = keywordMatches.length;
@@ -54,7 +57,7 @@ export class SemanticEvaluator {
 
       const evaluationParameters = {
         approach: EvaluationApproach.SEMANTIC,
-        threshold: DEFAULT_SEMANTIC_PASS_SCORE,
+        threshold,
       } as EvaluationParameters;
 
       return {
@@ -76,7 +79,7 @@ export class SemanticEvaluator {
         keywordMatches: [],
         evaluationParameters: {
           approach: EvaluationApproach.SEMANTIC,
-          threshold: DEFAULT_SEMANTIC_PASS_SCORE,
+          threshold,
         },
         evaluationApproachResult: {
           score: 0,


### PR DESCRIPTION
### Changes
**Prompt Editor visibility control**

- Added usePromptEditor prop to `<llm-test-runner>` (defaults to false), keeping the Prompt Editor button hidden unless explicitly opted in from the consumer application
- The prop is threaded from the root component down to LLMTestRunnerHeader, which conditionally renders the button

**Semantic evaluation threshold**

- Fixed SemanticEvaluator to respect the evaluationParameters.threshold value passed by the consumer, falling back to DEFAULT_SEMANTIC_PASS_SCORE (0.7) when not provided — consistent with how ROUGE-1, ROUGE-L, and BLEU already handled it