### PR TITLE
Implements dynamic expected outcome

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,8 @@ module.exports = {
       "error",
       {
         argsIgnorePattern: "^_",
-        varsIgnorePattern: "^h$", // Allow unused 'h' import for Stencil JSX
+        // Stencil JSX import `h`; omit bindings like `_` / `_removed` in destructuring
+        varsIgnorePattern: "^(_.*|h)$",
       },
     ],
     "@typescript-eslint/no-explicit-any": "warn",
@@ -61,7 +62,7 @@ module.exports = {
           "error",
           {
             argsIgnorePattern: "^_",
-            varsIgnorePattern: "^h$",
+            varsIgnorePattern: "^(_.*|h)$", // Stencil `h`; `_` / `_foo` omit bindings
           },
         ],
       },

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -27,8 +27,8 @@ import {
   DEFAULT_EXPECTED_OUTCOME_SCHEMA,
 } from '../../lib/test-cases/test-case-factory';
 import {
-  type ResolveExpectedOutcomeFn,
-  resolveDynamicExpectedOutcomesForRun,
+  type ExpectedOutcomeResolver,
+  resolveDynamicExpectedOutcomes,
 } from '../../lib/test-cases/dynamic-expected-outcome-resolver';
 import * as TestCaseMutations from '../../lib/test-cases/test-case-mutations';
 import { EvaluationService } from '../../lib/evaluation/evaluation-service';
@@ -61,7 +61,7 @@ export class LLMTestRunner {
   @Prop() delayMs?: number = 500;
   @Prop() useSave?: boolean = false;
   @Prop() usePromptEditor?: boolean = false;
-  @Prop() resolveExpectedOutcome?: ResolveExpectedOutcomeFn;
+  @Prop() resolveExpectedOutcome?: ExpectedOutcomeResolver;
   @Prop() initialTestCases?: TestCase[];
   @Prop() defaultExpectedOutcomeSchema?: ExpectedOutcomeSchema;
   @State() testCases: TestCase[] = [
@@ -187,7 +187,7 @@ export class LLMTestRunner {
     this.updateTestCase(testCase.id, { isRunning: true });
     const [llmSettled, resolutionSettled] = await Promise.allSettled([
       this.requestLlmText(testCase),
-      resolveDynamicExpectedOutcomesForRun(testCase, this.resolveExpectedOutcome),
+      resolveDynamicExpectedOutcomes(testCase, this.resolveExpectedOutcome),
     ]);
 
     const responseTime = Date.now() - startTime;

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -164,74 +164,74 @@ export class LLMTestRunner {
     );
   }
 
-  private buildBaseRunTestCase(
-    testCase: TestCase,
-    aiResponse: string,
-    startTime: number,
-  ): { baseTestCase: TestCase; responseTime: number } {
-    const responseTime = Date.now() - startTime;
-    return {
-      baseTestCase: {
-        ...testCase,
-        output: aiResponse,
-        responseTime,
-      },
-      responseTime,
-    };
+  private requestLlmText(testCase: TestCase): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.llmRequest.emit({
+        prompt: testCase.question,
+        resolve,
+        reject,
+      });
+    });
+  }
+
+  private throwError(reason: unknown): never {
+    throw reason instanceof Error ? reason : new Error(String(reason));
+  }
+
+  private addErrorMessage(reason: unknown, fallback: string): string {
+    return reason instanceof Error ? reason.message : fallback;
   }
 
   private async runSingleTest(testCase: TestCase): Promise<void> {
     const startTime = Date.now();
     this.updateTestCase(testCase.id, { isRunning: true });
-    return new Promise<void>((resolve, reject) => {
-      this.llmRequest.emit({
-        prompt: testCase.question,
-        resolve: async (aiResponse: string) => {
-          const { baseTestCase, responseTime } = this.buildBaseRunTestCase(
-            testCase,
-            aiResponse,
-            startTime,
-          );
-          try {
-            const resolvedTestCase = await resolveDynamicExpectedOutcomesForRun(
-              baseTestCase,
-              this.resolveExpectedOutcome,
-            );
+    const [llmSettled, resolutionSettled] = await Promise.allSettled([
+      this.requestLlmText(testCase),
+      resolveDynamicExpectedOutcomesForRun(testCase, this.resolveExpectedOutcome),
+    ]);
 
-            this.updateTestCase(testCase.id, {
-              isRunning: false,
-              output: aiResponse,
-              error: null,
-              responseTime,
-              expectedOutcome: resolvedTestCase.expectedOutcome,
-            });
+    const responseTime = Date.now() - startTime;
 
-            await this.evaluateResponse(resolvedTestCase);
-            resolve();
-          } catch (error) {
-            this.updateTestCase(testCase.id, {
-              isRunning: false,
-              output: aiResponse,
-              error:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to resolve dynamic expected outcome.',
-              responseTime,
-            });
-            reject(error);
-            return;
-          }
-        },
-        reject: (error: Error | unknown) => {
-          this.updateTestCase(testCase.id, {
-            isRunning: false,
-            output: null,
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
-          reject(error);
-        },
+    if (llmSettled.status === 'rejected') {
+      this.updateTestCase(testCase.id, {
+        isRunning: false,
+        output: null,
+        error: this.addErrorMessage(llmSettled.reason, 'Unknown error'),
+        responseTime,
       });
+      this.throwError(llmSettled.reason);
+    }
+    const aiResponse = llmSettled.value;
+
+    if (resolutionSettled.status === 'rejected') {
+      this.updateTestCase(testCase.id, {
+        isRunning: false,
+        output: aiResponse,
+        error: this.addErrorMessage(
+          resolutionSettled.reason,
+          'Failed to resolve dynamic expected outcome.',
+        ),
+        responseTime,
+      });
+      this.throwError(resolutionSettled.reason);
+    }
+    const resolvedTestCase = resolutionSettled.value;
+
+    const forEvaluationTestCase: TestCase = {
+      ...resolvedTestCase,
+      output: aiResponse,
+      responseTime,
+    };
+
+    this.updateTestCase(testCase.id, {
+      isRunning: false,
+      output: aiResponse,
+      error: null,
+      responseTime,
+      expectedOutcome: forEvaluationTestCase.expectedOutcome,
     });
+
+    await this.evaluateResponse(forEvaluationTestCase);
   }
 
   private deleteTestCase(id: string) {

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -26,6 +26,10 @@ import {
   createTestCaseFromInput,
   DEFAULT_EXPECTED_OUTCOME_SCHEMA,
 } from '../../lib/test-cases/test-case-factory';
+import {
+  type ResolveExpectedOutcomeFn,
+  resolveDynamicExpectedOutcomesForRun,
+} from '../../lib/test-cases/dynamic-expected-outcome-resolver';
 import * as TestCaseMutations from '../../lib/test-cases/test-case-mutations';
 import { EvaluationService } from '../../lib/evaluation/evaluation-service';
 import { validateTestCaseInputArray } from '../../schemas/test-case';
@@ -57,6 +61,7 @@ export class LLMTestRunner {
   @Prop() delayMs?: number = 500;
   @Prop() useSave?: boolean = false;
   @Prop() usePromptEditor?: boolean = false;
+  @Prop() resolveExpectedOutcome?: ResolveExpectedOutcomeFn;
   @Prop() initialTestCases?: TestCase[];
   @Prop() defaultExpectedOutcomeSchema?: ExpectedOutcomeSchema;
   @State() testCases: TestCase[] = [
@@ -159,6 +164,22 @@ export class LLMTestRunner {
     );
   }
 
+  private buildBaseRunTestCase(
+    testCase: TestCase,
+    aiResponse: string,
+    startTime: number,
+  ): { baseTestCase: TestCase; responseTime: number } {
+    const responseTime = Date.now() - startTime;
+    return {
+      baseTestCase: {
+        ...testCase,
+        output: aiResponse,
+        responseTime,
+      },
+      responseTime,
+    };
+  }
+
   private async runSingleTest(testCase: TestCase): Promise<void> {
     const startTime = Date.now();
     this.updateTestCase(testCase.id, { isRunning: true });
@@ -166,21 +187,40 @@ export class LLMTestRunner {
       this.llmRequest.emit({
         prompt: testCase.question,
         resolve: async (aiResponse: string) => {
-          const endTime = Date.now();
-          const responseTime = endTime - startTime;
-          this.updateTestCase(testCase.id, {
-            isRunning: false,
-            output: aiResponse,
-            error: null,
-            responseTime: responseTime,
-          });
+          const { baseTestCase, responseTime } = this.buildBaseRunTestCase(
+            testCase,
+            aiResponse,
+            startTime,
+          );
+          try {
+            const resolvedTestCase = await resolveDynamicExpectedOutcomesForRun(
+              baseTestCase,
+              this.resolveExpectedOutcome,
+            );
 
-          await this.evaluateResponse({
-            ...testCase,
-            output: aiResponse,
-            responseTime: responseTime,
-          });
-          resolve();
+            this.updateTestCase(testCase.id, {
+              isRunning: false,
+              output: aiResponse,
+              error: null,
+              responseTime,
+              expectedOutcome: resolvedTestCase.expectedOutcome,
+            });
+
+            await this.evaluateResponse(resolvedTestCase);
+            resolve();
+          } catch (error) {
+            this.updateTestCase(testCase.id, {
+              isRunning: false,
+              output: aiResponse,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to resolve dynamic expected outcome.',
+              responseTime,
+            });
+            reject(error);
+            return;
+          }
         },
         reject: (error: Error | unknown) => {
           this.updateTestCase(testCase.id, {

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -384,6 +384,7 @@ export class LLMTestRunner {
         <div class="test-runner-container__content">
           <LLMTestCases
             testCases={this.testCases}
+            dynamicResolutionSupported={!!this.resolveExpectedOutcome}
             onRun={testCase => this.runSingleTest(testCase).catch(() => {})}
             onDelete={id => this.deleteTestCase(id)}
             onAddTestCase={() => this.addNewTestCase()}

--- a/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
+++ b/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
@@ -1,6 +1,7 @@
 import { h, FunctionalComponent } from '@stencil/core';
 import {
   ExpectedOutcomeField,
+  type ExpectedOutcomeMode,
 } from '../../../types/llm-test-runner';
 import { ChipsConfig, FormFieldType, SelectConfig, TextAreaConfig } from '../../../lib/form/schema';
 import {
@@ -44,6 +45,25 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
     defaultValue: EvaluationApproach.EXACT,
   });
 
+  const buildOutcomeModeConfig = (index: number): SelectConfig => ({
+    name: `expectedOutcomeMode-${index}`,
+    fieldType: FormFieldType.SELECT,
+    label: 'Outcome Mode',
+    placeholder: 'Select outcome mode',
+    required: true,
+    optionList: ['static', 'dynamic'],
+    defaultValue: 'static',
+  });
+
+  const buildResolutionQueryConfig = (index: number): TextAreaConfig => ({
+    name: `expectedOutcomeResolutionQuery-${index}`,
+    fieldType: FormFieldType.TEXT_AREA,
+    label: 'Resolution Query',
+    placeholder: 'Query used to resolve expected value',
+    required: false,
+    rows: 2,
+  });
+
   const renderEvaluationSelector = (
     field: ExpectedOutcomeField,
     index: number,
@@ -70,12 +90,14 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
     <div class="expected-outcome-renderer">
       {(fields || []).map((field, index) => {
         if (field.type === 'textarea') {
+          const isDynamic = field.outcomeMode === 'dynamic';
           const config: TextAreaConfig = {
             name: `expectedOutcome-${index}`,
             fieldType: FormFieldType.TEXT_AREA,
             label: field.label,
-            placeholder: field.placeholder,
-            required: true,
+            placeholder: isDynamic ? 'Resolved on run' : field.placeholder,
+            required: !isDynamic,
+            readOnly: isDynamic,
             rows: field.rows || 2,
           };
           return (
@@ -92,6 +114,32 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
                   })
                 }
               />
+              <app-select
+                config={buildOutcomeModeConfig(index)}
+                value={field.outcomeMode || 'static'}
+                onValueChange={(e) =>
+                  emit({
+                    testCaseId,
+                    index,
+                    operation: 'set-outcome-mode',
+                    value: e.detail.value as ExpectedOutcomeMode,
+                  })
+                }
+              />
+              {field.outcomeMode === 'dynamic' && (
+                <app-textarea
+                  config={buildResolutionQueryConfig(index)}
+                  value={field.resolutionQuery || ''}
+                  onValueChange={(e) =>
+                    emit({
+                      testCaseId,
+                      index,
+                      operation: 'set-resolution-query',
+                      value: e.detail.value,
+                    })
+                  }
+                />
+              )}
               {renderEvaluationSelector(field, index)}
             </div>
           );

--- a/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
+++ b/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
@@ -17,6 +17,7 @@ export type ExpectedOutcomeChangeDetail = {
 interface ExpectedOutcomeRendererProps {
   testCaseId: string;
   fields: ExpectedOutcomeField[];
+  dynamicResolutionSupported?: boolean;
   onExpectedOutcomeChange: (
     e: CustomEvent<ExpectedOutcomeChangeDetail>,
   ) => void;
@@ -25,6 +26,7 @@ interface ExpectedOutcomeRendererProps {
 export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendererProps> = ({
   testCaseId,
   fields,
+  dynamicResolutionSupported = false,
   onExpectedOutcomeChange,
 }) => {
   const emit = (detail: ExpectedOutcomeChangeDetail) =>
@@ -90,7 +92,8 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
     <div class="expected-outcome-renderer">
       {(fields || []).map((field, index) => {
         if (field.type === 'textarea') {
-          const isDynamic = field.outcomeMode === 'dynamic';
+          const isDynamic =
+            dynamicResolutionSupported && field.outcomeMode === 'dynamic';
           const config: TextAreaConfig = {
             name: `expectedOutcome-${index}`,
             fieldType: FormFieldType.TEXT_AREA,
@@ -98,6 +101,9 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
             placeholder: isDynamic ? 'Resolved on run' : field.placeholder,
             required: !isDynamic,
             readOnly: isDynamic,
+            helpText: isDynamic
+              ? 'Filled automatically when the test is run'
+              : undefined,
             rows: field.rows || 2,
           };
           return (
@@ -114,32 +120,35 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
                   })
                 }
               />
-              <app-select
-                config={buildOutcomeModeConfig(index)}
-                value={field.outcomeMode || 'static'}
-                onValueChange={(e) =>
-                  emit({
-                    testCaseId,
-                    index,
-                    operation: 'set-outcome-mode',
-                    value: e.detail.value as ExpectedOutcomeMode,
-                  })
-                }
-              />
-              {field.outcomeMode === 'dynamic' && (
-                <app-textarea
-                  config={buildResolutionQueryConfig(index)}
-                  value={field.resolutionQuery || ''}
+              {dynamicResolutionSupported && (
+                <app-select
+                  config={buildOutcomeModeConfig(index)}
+                  value={field.outcomeMode || 'static'}
                   onValueChange={(e) =>
                     emit({
                       testCaseId,
                       index,
-                      operation: 'set-resolution-query',
-                      value: e.detail.value,
+                      operation: 'set-outcome-mode',
+                      value: e.detail.value as ExpectedOutcomeMode,
                     })
                   }
                 />
               )}
+              {dynamicResolutionSupported &&
+                field.outcomeMode === 'dynamic' && (
+                  <app-textarea
+                    config={buildResolutionQueryConfig(index)}
+                    value={field.resolutionQuery || ''}
+                    onValueChange={(e) =>
+                      emit({
+                        testCaseId,
+                        index,
+                        operation: 'set-resolution-query',
+                        value: e.detail.value,
+                      })
+                    }
+                  />
+                )}
               {renderEvaluationSelector(field, index)}
             </div>
           );

--- a/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
+++ b/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
@@ -149,7 +149,7 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
                     }
                   />
                 )}
-              {renderEvaluationSelector(field, index)}
+              {!isDynamic && renderEvaluationSelector(field, index)}
             </div>
           );
         }

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.tsx
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.tsx
@@ -11,6 +11,7 @@ import {
 
 export interface LLMTestCaseRowProps {
   testCase: TestCase;
+  dynamicResolutionSupported?: boolean;
   onRun: (testCase: TestCase) => void;
   onDelete: (id: string) => void;
   handleTestCaseChange: (
@@ -23,6 +24,7 @@ export interface LLMTestCaseRowProps {
 
 export const LLMTestCaseRow: FunctionalComponent<LLMTestCaseRowProps> = ({
   testCase,
+  dynamicResolutionSupported = false,
   onRun,
   onDelete,
   handleTestCaseChange,
@@ -56,6 +58,7 @@ export const LLMTestCaseRow: FunctionalComponent<LLMTestCaseRowProps> = ({
         <ExpectedOutcomeRenderer
           testCaseId={testCase.id}
           fields={testCase.expectedOutcome || []}
+          dynamicResolutionSupported={dynamicResolutionSupported}
           onExpectedOutcomeChange={onExpectedOutcomeChange}
         />
       </div>

--- a/src/components/llm-test-runner/test-cases/llm-test-cases.tsx
+++ b/src/components/llm-test-runner/test-cases/llm-test-cases.tsx
@@ -6,6 +6,7 @@ import { ExpectedOutcomeChangeDetail } from './expected-outcome-renderer';
 
 export interface LLMTestCasesProps {
   testCases: TestCase[];
+  dynamicResolutionSupported?: boolean;
   onRun: (testCase: TestCase) => void;
   onDelete: (id: string) => void;
   onAddTestCase: () => void;
@@ -19,6 +20,7 @@ export interface LLMTestCasesProps {
 
 export const LLMTestCases: FunctionalComponent<LLMTestCasesProps> = ({
   testCases,
+  dynamicResolutionSupported = false,
   onRun,
   onDelete,
   onAddTestCase,
@@ -37,6 +39,7 @@ export const LLMTestCases: FunctionalComponent<LLMTestCasesProps> = ({
       {testCases.map(testCase => (
         <LLMTestCaseRow
           testCase={testCase}
+          dynamicResolutionSupported={dynamicResolutionSupported}
           onRun={onRun}
           onDelete={onDelete}
           handleTestCaseChange={handleTestCaseChange}

--- a/src/components/llm-test-runner/tests/runSingleTest.spec.tsx
+++ b/src/components/llm-test-runner/tests/runSingleTest.spec.tsx
@@ -10,6 +10,7 @@ import { newSpecPage } from '@stencil/core/testing';
 import { LLMTestRunner } from '../llm-test-runner';
 import { TestCase, LLMRequestPayload } from '../../../types/llm-test-runner';
 import { EvaluationService } from '../../../lib/evaluation/evaluation-service';
+import { MISSING_RESOLVER_MESSAGE } from '../../../lib/test-cases/dynamic-expected-outcome-resolver';
 
 describe('LLMTestRunner', () => {
   let page: Awaited<ReturnType<typeof newSpecPage>>;
@@ -177,5 +178,39 @@ describe('LLMTestRunner', () => {
       }),
       expect.any(Function),
     );
+  });
+
+  it('fails run when dynamic expected outcome has no resolveExpectedOutcome prop', async () => {
+    const dynamicCase: TestCase = {
+      ...mockTestCase,
+      expectedOutcome: [
+        {
+          type: 'textarea',
+          label: 'Expected Outcome',
+          value: '',
+          outcomeMode: 'dynamic',
+          resolutionQuery: '$.expected.answer',
+        },
+      ],
+    };
+    page.rootInstance.testCases = [dynamicCase];
+    page.rootInstance.resolveExpectedOutcome = undefined;
+    await page.waitForChanges();
+
+    const llmRequestSpy = jest.fn();
+    page.root.addEventListener('llmRequest', llmRequestSpy);
+
+    const runButton = page.root.shadowRoot.querySelector(
+      'button[title="Run this test"]',
+    ) as HTMLButtonElement;
+    runButton.click();
+    await page.waitForChanges();
+
+    const eventPayload = getFirstEventFromSpy(llmRequestSpy).detail;
+    await eventPayload.resolve('Model response');
+    await page.waitForChanges();
+
+    expect(page.rootInstance.testCases[0].error).toBe(MISSING_RESOLVER_MESSAGE);
+    expect(mockEvaluateTestCase).not.toHaveBeenCalled();
   });
 });

--- a/src/components/llm-test-runner/tests/runSingleTest.spec.tsx
+++ b/src/components/llm-test-runner/tests/runSingleTest.spec.tsx
@@ -126,4 +126,56 @@ describe('LLMTestRunner', () => {
     expect(page.rootInstance.testCases[0].error).toBe('API Error');
     expect(mockEvaluateTestCase).not.toHaveBeenCalled();
   });
+
+  it('resolves dynamic expected outcome before evaluation', async () => {
+    const dynamicCase: TestCase = {
+      ...mockTestCase,
+      expectedOutcome: [
+        {
+          type: 'textarea',
+          label: 'Expected Outcome',
+          value: '',
+          outcomeMode: 'dynamic',
+          resolutionQuery: '$.expected.answer',
+        },
+      ],
+    };
+    page.rootInstance.testCases = [dynamicCase];
+    const resolveExpectedOutcome = jest
+      .fn()
+      .mockImplementation(async () => 'Resolved Expected Value');
+    page.rootInstance.resolveExpectedOutcome = resolveExpectedOutcome;
+    await page.waitForChanges();
+
+    const llmRequestSpy = jest.fn();
+    page.root.addEventListener('llmRequest', llmRequestSpy);
+
+    const runButton = page.root.shadowRoot.querySelector(
+      'button[title="Run this test"]',
+    ) as HTMLButtonElement;
+    runButton.click();
+    await page.waitForChanges();
+
+    const eventPayload = getFirstEventFromSpy(llmRequestSpy).detail;
+    await eventPayload.resolve('Model response');
+    await page.waitForChanges();
+
+    expect(resolveExpectedOutcome).toHaveBeenCalledWith('$.expected.answer', {
+      testCase: expect.objectContaining({
+        id: dynamicCase.id,
+        output: 'Model response',
+      }),
+      fieldIndex: 0,
+    });
+    expect(mockEvaluateTestCase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedOutcome: [
+          expect.objectContaining({
+            value: 'Resolved Expected Value',
+          }),
+        ],
+      }),
+      expect.any(Function),
+    );
+  });
 });

--- a/src/components/llm-test-runner/tests/runSingleTest.spec.tsx
+++ b/src/components/llm-test-runner/tests/runSingleTest.spec.tsx
@@ -128,7 +128,7 @@ describe('LLMTestRunner', () => {
     expect(mockEvaluateTestCase).not.toHaveBeenCalled();
   });
 
-  it('resolves dynamic expected outcome before evaluation', async () => {
+  it('resolves dynamic expected outcome in parallel with LLM, then evaluates', async () => {
     const dynamicCase: TestCase = {
       ...mockTestCase,
       expectedOutcome: [
@@ -158,13 +158,14 @@ describe('LLMTestRunner', () => {
     await page.waitForChanges();
 
     const eventPayload = getFirstEventFromSpy(llmRequestSpy).detail;
+    expect(resolveExpectedOutcome).toHaveBeenCalled();
     await eventPayload.resolve('Model response');
     await page.waitForChanges();
 
     expect(resolveExpectedOutcome).toHaveBeenCalledWith('$.expected.answer', {
       testCase: expect.objectContaining({
         id: dynamicCase.id,
-        output: 'Model response',
+        question: dynamicCase.question,
       }),
       fieldIndex: 0,
     });

--- a/src/lib/evaluation/evaluation-service.ts
+++ b/src/lib/evaluation/evaluation-service.ts
@@ -31,17 +31,25 @@ export class EvaluationService {
       return;
     }
 
-    const fields: FieldEvaluationInput[] = (testCase.expectedOutcome || []).map(
-      (field, index) => ({
-        index,
-        label: field.label,
-        type: field.type,
-        expectedValue: getFieldExpectedValue(field),
-        evaluationParameters: normalizeEvaluationParametersForField(
-          field.type,
-          field.evaluationParameters,
-        ),
-      }),
+    const fields: FieldEvaluationInput[] = (testCase.expectedOutcome || []).flatMap(
+      (field, index) => {
+        if (field.type === 'textarea' && field.outcomeMode === 'dynamic') {
+          return [];
+        }
+
+        return [
+          {
+            index,
+            label: field.label,
+            type: field.type,
+            expectedValue: getFieldExpectedValue(field),
+            evaluationParameters: normalizeEvaluationParametersForField(
+              field.type,
+              field.evaluationParameters,
+            ),
+          },
+        ];
+      },
     );
 
     const evaluationRequest: EvaluationRequestV2 = {

--- a/src/lib/form/components/app-textarea.css
+++ b/src/lib/form/components/app-textarea.css
@@ -30,6 +30,23 @@
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
+.textarea-wrapper--read-only .textarea-label {
+  color: var(--muted-foreground);
+}
+
+.textarea-element:read-only {
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border-color: var(--border);
+  cursor: not-allowed;
+  resize: none;
+}
+
+.textarea-element:read-only:focus {
+  border-color: var(--border);
+  box-shadow: none;
+}
+
 .help-text {
   margin-top: var(--spacing-1);
   font-size: var(--font-size-xs);

--- a/src/lib/form/components/app-textarea.tsx
+++ b/src/lib/form/components/app-textarea.tsx
@@ -35,7 +35,12 @@ export class AppTextarea {
     };
 
     return (
-      <div class="textarea-wrapper">
+      <div
+        class={{
+          'textarea-wrapper': true,
+          'textarea-wrapper--read-only': !!c.readOnly,
+        }}
+      >
         {c.label && (
           <label class="textarea-label" htmlFor={c.name}>
             {c.label}

--- a/src/lib/test-cases/dynamic-expected-outcome-resolver.spec.ts
+++ b/src/lib/test-cases/dynamic-expected-outcome-resolver.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+import type { TestCase } from '../../types/llm-test-runner';
+import type { ExpectedOutcomeResolver } from './dynamic-expected-outcome-resolver';
+import {
+  MISSING_RESOLVER_MESSAGE,
+  resolveDynamicExpectedOutcomes,
+} from './dynamic-expected-outcome-resolver';
+
+function baseCase(overrides: Partial<TestCase> = {}): TestCase {
+  return {
+    id: 't1',
+    question: 'Q?',
+    expectedOutcome: [
+      {
+        type: 'textarea',
+        label: 'A',
+        value: '',
+        outcomeMode: 'static',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('resolveDynamicExpectedOutcomes', () => {
+  it('returns the same instance when there is no dynamic textarea', async () => {
+    const tc = baseCase();
+    const out = await resolveDynamicExpectedOutcomes(tc);
+    expect(out).toBe(tc);
+  });
+
+  it('throws when dynamic fields exist but resolver is omitted', async () => {
+    const tc = baseCase({
+      expectedOutcome: [
+        {
+          type: 'textarea',
+          label: 'Dyn',
+          value: '',
+          outcomeMode: 'dynamic',
+          resolutionQuery: 'q1',
+        },
+      ],
+    });
+    await expect(resolveDynamicExpectedOutcomes(tc)).rejects.toThrow(
+      MISSING_RESOLVER_MESSAGE,
+    );
+  });
+
+  it('calls resolver and writes resolved value on the dynamic textarea', async () => {
+    const tc = baseCase({
+      expectedOutcome: [
+        {
+          type: 'textarea',
+          label: 'Dyn',
+          value: '',
+          outcomeMode: 'dynamic',
+          resolutionQuery: 'SELECT 1',
+        },
+      ],
+    });
+    const resolver = jest.fn() as jest.MockedFunction<ExpectedOutcomeResolver>;
+    resolver.mockResolvedValue('from-db');
+    const out = await resolveDynamicExpectedOutcomes(tc, resolver);
+
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(resolver).toHaveBeenCalledWith('SELECT 1', {
+      testCase: tc,
+      fieldIndex: 0,
+    });
+    expect(out.expectedOutcome?.[0]).toMatchObject({
+      type: 'textarea',
+      outcomeMode: 'dynamic',
+      value: 'from-db',
+    });
+    expect(out).not.toBe(tc);
+  });
+
+  it('resolves several dynamic textareas by index when another field sits between them', async () => {
+    const tc = baseCase({
+      expectedOutcome: [
+        {
+          type: 'textarea',
+          label: 'D0',
+          value: '',
+          outcomeMode: 'dynamic',
+          resolutionQuery: 'a',
+        },
+        {
+          type: 'chips-input',
+          label: 'C',
+          value: ['x'],
+        },
+        {
+          type: 'textarea',
+          label: 'D2',
+          value: '',
+          outcomeMode: 'dynamic',
+          resolutionQuery: 'b',
+        },
+      ],
+    });
+    const resolver = jest.fn() as jest.MockedFunction<ExpectedOutcomeResolver>;
+    resolver.mockImplementation(async (q, ctx) => `${q}:${ctx.fieldIndex}`);
+
+    const out = await resolveDynamicExpectedOutcomes(tc, resolver);
+
+    expect(resolver).toHaveBeenCalledTimes(2);
+    expect(resolver).toHaveBeenCalledWith('a', { testCase: tc, fieldIndex: 0 });
+    expect(resolver).toHaveBeenCalledWith('b', { testCase: tc, fieldIndex: 2 });
+    expect(out.expectedOutcome?.[0]).toMatchObject({ value: 'a:0' });
+    expect(out.expectedOutcome?.[1]).toMatchObject({ type: 'chips-input' });
+    expect(out.expectedOutcome?.[2]).toMatchObject({ value: 'b:2' });
+  });
+
+  it('does not invoke resolver for static textarea or non-textarea fields', async () => {
+    const tc = baseCase({
+      expectedOutcome: [
+        {
+          type: 'textarea',
+          label: 'Static',
+          value: 'keep',
+          outcomeMode: 'static',
+        },
+        {
+          type: 'select',
+          label: 'S',
+          options: ['a'],
+          value: 'a',
+        },
+      ],
+    });
+    const resolver = jest.fn() as jest.MockedFunction<ExpectedOutcomeResolver>;
+    const out = await resolveDynamicExpectedOutcomes(tc, resolver);
+    expect(resolver).not.toHaveBeenCalled();
+    expect(out).toBe(tc);
+  });
+});

--- a/src/lib/test-cases/dynamic-expected-outcome-resolver.ts
+++ b/src/lib/test-cases/dynamic-expected-outcome-resolver.ts
@@ -9,6 +9,9 @@ export type ResolveExpectedOutcomeFn = (
   context: { testCase: TestCase; fieldIndex: number },
 ) => Promise<string>;
 
+export const MISSING_RESOLVER_MESSAGE =
+  'resolveExpectedOutcome is required when a test case has dynamic expected outcomes.';
+
 type ResolvedDynamicValue = { index: number; value: string };
 
 function isDynamicTextareaField(
@@ -47,10 +50,6 @@ export async function resolveDynamicExpectedOutcomes(
   testCase: TestCase,
   resolver?: ResolveExpectedOutcomeFn,
 ): Promise<TestCase> {
-  if (!resolver) {
-    return testCase;
-  }
-
   const dynamicFields = (testCase.expectedOutcome || []).flatMap((field, index) => {
     if (!isDynamicTextareaField(field)) {
       return [];
@@ -60,6 +59,10 @@ export async function resolveDynamicExpectedOutcomes(
 
   if (dynamicFields.length === 0) {
     return testCase;
+  }
+
+  if (!resolver) {
+    throw new Error(MISSING_RESOLVER_MESSAGE);
   }
 
   const resolvedValues = await Promise.all(

--- a/src/lib/test-cases/dynamic-expected-outcome-resolver.ts
+++ b/src/lib/test-cases/dynamic-expected-outcome-resolver.ts
@@ -4,7 +4,7 @@ import {
   TextareaExpectedOutcomeField,
 } from '../../types/llm-test-runner';
 
-export type ResolveExpectedOutcomeFn = (
+export type ExpectedOutcomeResolver = (
   resolutionQuery: string,
   context: { testCase: TestCase; fieldIndex: number },
 ) => Promise<string>;
@@ -48,7 +48,7 @@ function applyResolvedDynamicValues(
 
 export async function resolveDynamicExpectedOutcomes(
   testCase: TestCase,
-  resolver?: ResolveExpectedOutcomeFn,
+  resolver?: ExpectedOutcomeResolver,
 ): Promise<TestCase> {
   const dynamicFields = (testCase.expectedOutcome || []).flatMap((field, index) => {
     if (!isDynamicTextareaField(field)) {
@@ -76,11 +76,4 @@ export async function resolveDynamicExpectedOutcomes(
   );
 
   return applyResolvedDynamicValues(testCase, resolvedValues);
-}
-
-export async function resolveDynamicExpectedOutcomesForRun(
-  baseTestCase: TestCase,
-  resolveExpectedOutcome?: ResolveExpectedOutcomeFn,
-): Promise<TestCase> {
-  return resolveDynamicExpectedOutcomes(baseTestCase, resolveExpectedOutcome);
 }

--- a/src/lib/test-cases/dynamic-expected-outcome-resolver.ts
+++ b/src/lib/test-cases/dynamic-expected-outcome-resolver.ts
@@ -1,0 +1,83 @@
+import {
+  ExpectedOutcomeField,
+  TestCase,
+  TextareaExpectedOutcomeField,
+} from '../../types/llm-test-runner';
+
+export type ResolveExpectedOutcomeFn = (
+  resolutionQuery: string,
+  context: { testCase: TestCase; fieldIndex: number },
+) => Promise<string>;
+
+type ResolvedDynamicValue = { index: number; value: string };
+
+function isDynamicTextareaField(
+  field: ExpectedOutcomeField,
+): field is TextareaExpectedOutcomeField {
+  return field.type === 'textarea' && field.outcomeMode === 'dynamic';
+}
+
+function applyResolvedDynamicValues(
+  testCase: TestCase,
+  resolvedValues: ResolvedDynamicValue[],
+): TestCase {
+  if (resolvedValues.length === 0) {
+    return testCase;
+  }
+
+  const expectedOutcome = [...(testCase.expectedOutcome || [])];
+  for (const resolved of resolvedValues) {
+    const field = expectedOutcome[resolved.index];
+    if (!field || !isDynamicTextareaField(field)) {
+      continue;
+    }
+    expectedOutcome[resolved.index] = {
+      ...field,
+      value: resolved.value,
+    };
+  }
+
+  return {
+    ...testCase,
+    expectedOutcome,
+  };
+}
+
+export async function resolveDynamicExpectedOutcomes(
+  testCase: TestCase,
+  resolver?: ResolveExpectedOutcomeFn,
+): Promise<TestCase> {
+  if (!resolver) {
+    return testCase;
+  }
+
+  const dynamicFields = (testCase.expectedOutcome || []).flatMap((field, index) => {
+    if (!isDynamicTextareaField(field)) {
+      return [];
+    }
+    return [{ field, index }];
+  });
+
+  if (dynamicFields.length === 0) {
+    return testCase;
+  }
+
+  const resolvedValues = await Promise.all(
+    dynamicFields.map(async ({ field, index }) => ({
+      index,
+      value: await resolver(
+        field.resolutionQuery || '',
+        { testCase, fieldIndex: index },
+      ),
+    })),
+  );
+
+  return applyResolvedDynamicValues(testCase, resolvedValues);
+}
+
+export async function resolveDynamicExpectedOutcomesForRun(
+  baseTestCase: TestCase,
+  resolveExpectedOutcome?: ResolveExpectedOutcomeFn,
+): Promise<TestCase> {
+  return resolveDynamicExpectedOutcomes(baseTestCase, resolveExpectedOutcome);
+}

--- a/src/lib/test-cases/test-case-mutations.ts
+++ b/src/lib/test-cases/test-case-mutations.ts
@@ -91,7 +91,7 @@ export function applyExpectedOutcomeChange(
       }
       const mode = change.value;
       if (mode === 'static') {
-        const { resolutionQuery: _removed, ...rest } = target;
+        const { resolutionQuery: _, ...rest } = target;
         expectedOutcome[index] = {
           ...rest,
           outcomeMode: 'static',

--- a/src/lib/test-cases/test-case-mutations.ts
+++ b/src/lib/test-cases/test-case-mutations.ts
@@ -1,4 +1,7 @@
-import { TestCase } from '../../types/llm-test-runner';
+import {
+  TestCase,
+  type ExpectedOutcomeMode,
+} from '../../types/llm-test-runner';
 import { EvaluationApproach } from '../evaluation/constants';
 import { normalizeEvaluationParametersForField } from '../evaluation/field-evaluation-approach';
 
@@ -22,6 +25,16 @@ export type ExpectedOutcomeChange =
       index: number;
       operation: 'set-evaluation-approach';
       value: EvaluationApproach;
+    }
+  | {
+      index: number;
+      operation: 'set-outcome-mode';
+      value: ExpectedOutcomeMode;
+    }
+  | {
+      index: number;
+      operation: 'set-resolution-query';
+      value: string;
     };
 
 export function applyExpectedOutcomeChange(
@@ -39,6 +52,9 @@ export function applyExpectedOutcomeChange(
   switch (change.operation) {
     case 'set-value': {
       if (target.type === 'chips-input') {
+        return testCase;
+      }
+      if (target.type === 'textarea' && target.outcomeMode === 'dynamic') {
         return testCase;
       }
       expectedOutcome[index] = {
@@ -69,6 +85,37 @@ export function applyExpectedOutcomeChange(
     }
     case 'set-evaluation-approach':
       return updateExpectedOutcomeFieldApproach(testCase, index, change.value);
+    case 'set-outcome-mode': {
+      if (target.type !== 'textarea') {
+        return testCase;
+      }
+      const mode = change.value;
+      if (mode === 'static') {
+        const { resolutionQuery: _removed, ...rest } = target;
+        expectedOutcome[index] = {
+          ...rest,
+          outcomeMode: 'static',
+          value: '',
+        };
+      } else {
+        expectedOutcome[index] = {
+          ...target,
+          outcomeMode: 'dynamic',
+          value: '',
+        };
+      }
+      return { ...testCase, expectedOutcome };
+    }
+    case 'set-resolution-query': {
+      if (target.type !== 'textarea' || target.outcomeMode !== 'dynamic') {
+        return testCase;
+      }
+      expectedOutcome[index] = {
+        ...target,
+        resolutionQuery: change.value,
+      };
+      return { ...testCase, expectedOutcome };
+    }
   }
 }
 

--- a/src/schemas/expected-outcome.schema.spec.ts
+++ b/src/schemas/expected-outcome.schema.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { expectedOutcomeFieldSchema } from './expected-outcome';
+
+describe('expected outcome schemas', () => {
+  it('defaults outcomeMode to static when omitted (textarea only)', () => {
+    const data = expectedOutcomeFieldSchema.parse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: 'answer',
+    });
+
+    expect(data.type).toBe('textarea');
+    if (data.type !== 'textarea') return;
+    expect(data.outcomeMode).toBe('static');
+    expect(data.resolutionQuery).toBeUndefined();
+  });
+
+  it('allows dynamic textarea with resolutionQuery before run fills value', () => {
+    const data = expectedOutcomeFieldSchema.parse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: '',
+      outcomeMode: 'dynamic',
+      resolutionQuery:
+        'SELECT name FROM students WHERE student_id = 1',
+    });
+
+    expect(data.type).toBe('textarea');
+    if (data.type !== 'textarea') return;
+    expect(data.outcomeMode).toBe('dynamic');
+    expect(data.resolutionQuery).toBe(
+      'SELECT name FROM students WHERE student_id = 1',
+    );
+  });
+});

--- a/src/schemas/expected-outcome.schema.spec.ts
+++ b/src/schemas/expected-outcome.schema.spec.ts
@@ -33,4 +33,17 @@ describe('expected outcome schemas', () => {
       'SELECT name FROM students WHERE student_id = 1',
     );
   });
+
+  it('rejects dynamic textarea with empty resolutionQuery', () => {
+    const parsed = expectedOutcomeFieldSchema.safeParse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: '',
+      outcomeMode: 'dynamic',
+      resolutionQuery: '   ',
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error.issues[0].path).toEqual(['resolutionQuery']);
+  });
 });

--- a/src/schemas/expected-outcome.ts
+++ b/src/schemas/expected-outcome.ts
@@ -8,6 +8,9 @@ const optionalString = z.string().optional();
 const selectOptionsSchema = z.array(nonEmptyString).min(1);
 const optionalNumber = z.number().optional();
 
+export const expectedOutcomeModeSchema = z.enum(['static', 'dynamic']);
+export type ExpectedOutcomeMode = z.infer<typeof expectedOutcomeModeSchema>;
+
 const evaluationParametersSchema = z.object({
   approach: z.enum(EvaluationApproach),
   threshold: optionalNumber,
@@ -85,6 +88,8 @@ export const expectedOutcomeFieldSchema = z.discriminatedUnion('type', [
   }),
   defaultFieldDefinitions.textarea.extend({
     value: z.string(),
+    outcomeMode: expectedOutcomeModeSchema.default('static'),
+    resolutionQuery: z.string().optional(),
   }),
   defaultFieldDefinitions.chipsInput.extend({
     value: z.array(z.string()).superRefine((values, ctx) => {
@@ -118,7 +123,7 @@ export type ExpectedOutcomeSchemaField = z.infer<
   typeof expectedOutcomeSchemaFieldSchema
 >;
 export type ExpectedOutcomeSchema = z.infer<typeof expectedOutcomeSchemaSchema>;
-export type ExpectedOutcomeField = z.infer<typeof expectedOutcomeFieldSchema>;
+export type ExpectedOutcomeField = z.input<typeof expectedOutcomeFieldSchema>;
 export type ExpectedOutcomeFieldType = ExpectedOutcomeField['type'];
 export type ExpectedOutcomeBase = z.infer<typeof defaultExpectedOutcomeBaseSchema>;
 

--- a/src/schemas/expected-outcome.ts
+++ b/src/schemas/expected-outcome.ts
@@ -86,11 +86,24 @@ export const expectedOutcomeFieldSchema = z.discriminatedUnion('type', [
   defaultFieldDefinitions.text.extend({
     value: z.string(),
   }),
-  defaultFieldDefinitions.textarea.extend({
-    value: z.string(),
-    outcomeMode: expectedOutcomeModeSchema.default('static'),
-    resolutionQuery: z.string().optional(),
-  }),
+  defaultFieldDefinitions.textarea
+    .extend({
+      value: z.string(),
+      outcomeMode: expectedOutcomeModeSchema.default('static'),
+      resolutionQuery: z.string().optional(),
+    })
+    .superRefine((field, ctx) => {
+      if (
+        field.outcomeMode === 'dynamic' &&
+        (!field.resolutionQuery || field.resolutionQuery.trim().length === 0)
+      ) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['resolutionQuery'],
+          message: 'resolutionQuery is required when outcomeMode is dynamic.',
+        });
+      }
+    }),
   defaultFieldDefinitions.chipsInput.extend({
     value: z.array(z.string()).superRefine((values, ctx) => {
       if (hasDuplicateChips(values)) {

--- a/src/schemas/test-case.ts
+++ b/src/schemas/test-case.ts
@@ -21,8 +21,8 @@ export const testCaseSchema = z.object({
   responseTime: z.number().optional(),
 });
 
-export type TestCaseInput = z.infer<typeof testCaseInputSchema>;
-export type TestCase = z.infer<typeof testCaseSchema>;
+export type TestCaseInput = z.input<typeof testCaseInputSchema>;
+export type TestCase = z.input<typeof testCaseSchema>;
 
 export function validateTestCaseInput(
   data: unknown,

--- a/src/types/expected-outcome.ts
+++ b/src/types/expected-outcome.ts
@@ -1,4 +1,5 @@
 export type {
+  ExpectedOutcomeMode,
   ExpectedOutcomeSchemaField,
   ExpectedOutcomeSchema,
   ExpectedOutcomeField,

--- a/src/types/llm-test-runner.ts
+++ b/src/types/llm-test-runner.ts
@@ -1,6 +1,7 @@
 import type { TestCase } from './test-case';
 
 export type {
+  ExpectedOutcomeMode,
   ExpectedOutcomeFieldType,
   ExpectedOutcomeBase,
   ExpectedOutcomeSchema,


### PR DESCRIPTION
Users can dynamic expected from their own data at run time instead of typing a fixed string every time
Evaluation is hidden for dynamic expected outcome
LLM output and dynamic expected outcomes are executed in parallel

