### PR TITLE
feat: run evaluation strategies headless

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "nodemon": "^3.1.11",
         "prettier": "^3.6.2",
         "puppeteer": "^24.3.0",
+        "tsx": "^4.21.0",
         "wait-on": "^9.0.3"
       },
       "peerDependencies": {
@@ -558,6 +559,448 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
       "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -4500,6 +4943,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -5349,6 +5834,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/get-uri": {
@@ -8842,6 +9340,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -9652,6 +10160,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
       "require": "./dist/components/*",
       "types": "./dist/components/*"
     },
+    "./eval": {
+      "import": "./dist/collection/lib/evaluation/eval-suite-runner.js",
+      "types": "./dist/types/lib/evaluation/eval-suite-runner.d.ts"
+    },
     "./loader": {
       "import": "./loader/index.js",
       "require": "./loader/index.cjs",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "just-publish": "npm publish --access=public",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint src --ext .ts,.tsx --fix",
-    "license-check": "licensee"
+    "license-check": "licensee",
+    "evaluate": "tsx scripts/evaluate.ts"
   },
   "dependencies": {
     "@google/genai": "^1.40.0",
@@ -92,6 +93,7 @@
     "nodemon": "^3.1.11",
     "prettier": "^3.6.2",
     "puppeteer": "^24.3.0",
+    "tsx": "^4.21.0",
     "wait-on": "^9.0.3"
   },
   "peerDependencies": {

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -2,21 +2,31 @@
 /**
  * evaluate.ts — run evaluation strategies from the command line
  *
- * Usage:
+ * Single mode:
  *   npx tsx scripts/evaluate.ts --exact    --expected "hello world" --actual "hello world greeting"
  *   npx tsx scripts/evaluate.ts --rouge1   --expected "machine learning" --actual "deep learning and ML" --threshold 0.5
  *   npx tsx scripts/evaluate.ts --rougeL   --expected "natural language" --actual "NLP processing"
  *   npx tsx scripts/evaluate.ts --bleu     --expected "the cat sat" --actual "the cat sat on the mat"
  *   npx tsx scripts/evaluate.ts --semantic --expected "happy" --actual "joyful and content"
+ *
+ * Suite mode:
+ *   npx tsx scripts/evaluate.ts --file path/to/evals.json
  */
 
+import { readFileSync } from 'fs';
 import { performEvaluation } from '../src/lib/evaluation/evaluators/exact/exact';
 import { performRouge1Evaluation } from '../src/lib/evaluation/evaluators/rouge1-evaluator';
 import { performRougeLEvaluation } from '../src/lib/evaluation/evaluators/rougeL-evaluator';
 import { performBleuEvaluation } from '../src/lib/evaluation/evaluators/bleu/bleu-evaluator';
 import { performSemanticEvaluation } from '../src/lib/evaluation/evaluators/semantic/index';
 import { EvaluationApproach } from '../src/lib/evaluation/constants';
+import {
+  parseEvalSuite,
+  runEvalSuite,
+} from '../src/lib/evaluation/eval-suite-runner';
 import type { EvaluationRequest } from '../src/lib/evaluation/types';
+
+// ── single-mode config ──────────────────────────────────────────────────────
 
 const APPROACHES: Record<string, EvaluationApproach> = {
   '--exact': EvaluationApproach.EXACT,
@@ -26,23 +36,32 @@ const APPROACHES: Record<string, EvaluationApproach> = {
   '--semantic': EvaluationApproach.SEMANTIC,
 };
 
-const EVALUATORS: Record<EvaluationApproach, (req: EvaluationRequest) => any> = {
-  [EvaluationApproach.EXACT]: performEvaluation,
-  [EvaluationApproach.ROUGE_1]: performRouge1Evaluation,
-  [EvaluationApproach.ROUGE_L]: performRougeLEvaluation,
-  [EvaluationApproach.BLEU]: performBleuEvaluation,
-  [EvaluationApproach.SEMANTIC]: performSemanticEvaluation,
-};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const EVALUATORS: Record<EvaluationApproach, (req: EvaluationRequest) => any> =
+  {
+    [EvaluationApproach.EXACT]: performEvaluation,
+    [EvaluationApproach.ROUGE_1]: performRouge1Evaluation,
+    [EvaluationApproach.ROUGE_L]: performRougeLEvaluation,
+    [EvaluationApproach.BLEU]: performBleuEvaluation,
+    [EvaluationApproach.SEMANTIC]: performSemanticEvaluation,
+  };
+
+// ── usage ───────────────────────────────────────────────────────────────────
 
 function usage() {
-  console.error(`Usage: npx tsx scripts/evaluate.ts <strategy> --expected <string> --actual <string> [--threshold <number>]
+  console.error(`Usage:
+  npx tsx scripts/evaluate.ts <strategy> --expected <string> --actual <string> [--threshold <number>]
+  npx tsx scripts/evaluate.ts --file <evals.json>
 
-Strategies (pick one):
+Strategies (pick one, single mode):
   --exact      Literal keyword matching
   --rouge1     ROUGE-1 unigram overlap (default threshold: 0.7)
   --rougeL     ROUGE-L longest common subsequence (default threshold: 0.7)
   --bleu       BLEU n-gram precision (default threshold: 0.7)
   --semantic   Transformer embedding cosine similarity (default threshold: 0.7)
+
+Suite mode:
+  --file       Path to an evals.json file (runs all evals in the suite)
 
 Options:
   --expected   Expected outcome text (keywords separated by commas or newlines)
@@ -50,16 +69,34 @@ Options:
   --threshold  Pass/fail threshold, 0-1 (optional, overrides default)
 
 Examples:
-  npx tsx scripts/evaluate.ts --exact    --expected "hello world" --actual "hello world greeting"
-  npx tsx scripts/evaluate.ts --rouge1   --expected "machine learning" --actual "deep learning and ML" --threshold 0.5
-  npx tsx scripts/evaluate.ts --semantic --expected "happy" --actual "joyful and content"`);
+  npx tsx scripts/evaluate.ts --exact --expected "hello world" --actual "hello world greeting"
+  npx tsx scripts/evaluate.ts --rouge1 --expected "ML" --actual "deep learning and ML" --threshold 0.5
+  npx tsx scripts/evaluate.ts --file tests/evals.json`);
 }
 
-function parseArgs(argv: string[]) {
+// ── arg parsing ─────────────────────────────────────────────────────────────
+
+interface SingleArgs {
+  mode: 'single';
+  approach: EvaluationApproach;
+  expected: string;
+  actual: string;
+  threshold?: number;
+}
+
+interface SuiteArgs {
+  mode: 'suite';
+  filePath: string;
+}
+
+type Args = SingleArgs | SuiteArgs;
+
+function parseArgs(argv: string[]): Args {
   let expected: string | undefined;
   let actual: string | undefined;
   let threshold: number | undefined;
   let approach: EvaluationApproach | undefined;
+  let filePath: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -69,9 +106,16 @@ function parseArgs(argv: string[]) {
       process.exit(0);
     }
 
+    if (arg === '--file') {
+      filePath = argv[++i];
+      continue;
+    }
+
     if (arg in APPROACHES) {
       if (approach) {
-        console.error(`ERROR: only one strategy allowed (got both --${approach} and ${arg})`);
+        console.error(
+          `ERROR: only one strategy allowed (got both --${approach} and ${arg})`,
+        );
         process.exit(1);
       }
       approach = APPROACHES[arg];
@@ -100,8 +144,14 @@ function parseArgs(argv: string[]) {
     process.exit(1);
   }
 
+  if (filePath) {
+    return { mode: 'suite', filePath };
+  }
+
   if (!approach) {
-    console.error('ERROR: a strategy is required (--exact, --rouge1, --rougeL, --bleu, --semantic)');
+    console.error(
+      'ERROR: a strategy or --file is required (--exact, --rouge1, --rougeL, --bleu, --semantic, --file)',
+    );
     usage();
     process.exit(1);
   }
@@ -114,12 +164,47 @@ function parseArgs(argv: string[]) {
     process.exit(1);
   }
 
-  return { approach, expected, actual, threshold };
+  return { mode: 'single', approach, expected, actual, threshold };
 }
 
-async function main() {
-  const args = parseArgs(process.argv.slice(2));
+// ── suite runner ────────────────────────────────────────────────────────────
 
+async function runSuiteMode(filePath: string) {
+  const json = readFileSync(filePath, 'utf8');
+  const suite = parseEvalSuite(json);
+  const result = await runEvalSuite(suite);
+
+  const suiteLabel = result.suite ? ` (${result.suite})` : '';
+  console.log(`Eval suite${suiteLabel}: ${result.total} eval(s)\n`);
+
+  for (const r of result.results) {
+    const icon = r.passed ? '\u2713' : '\u2717';
+    const label = r.passed ? 'PASS' : 'FAIL';
+    console.log(`  ${icon} ${label}  eval ${r.id}`);
+    for (const f of r.fields) {
+      const fieldIcon = f.passed ? '+' : '-';
+      console.log(
+        `       ${fieldIcon} ${f.label}: ${f.approach} score=${f.score.toFixed(3)}`,
+      );
+      for (const kw of f.keywordScores) {
+        const kwIcon = kw.passed ? '+' : '-';
+        console.log(
+          `         ${kwIcon} "${kw.keyword}" ${kw.score.toFixed(3)}`,
+        );
+      }
+    }
+  }
+
+  const passPercent = (result.passRate * 100).toFixed(0);
+  console.log(
+    `\n${result.passed}/${result.total} passed (${passPercent}%)`,
+  );
+  process.exit(result.failed > 0 ? 1 : 0);
+}
+
+// ── single runner ───────────────────────────────────────────────────────────
+
+async function runSingleMode(args: SingleArgs) {
   const request: EvaluationRequest = {
     testCaseId: 'cli',
     question: '',
@@ -140,6 +225,18 @@ async function main() {
 
   console.log(JSON.stringify(result, null, 2));
   process.exit(result.passed ? 0 : 1);
+}
+
+// ── main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.mode === 'suite') {
+    await runSuiteMode(args.filePath);
+  } else {
+    await runSingleMode(args);
+  }
 }
 
 main();

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * evaluate.ts — run evaluation strategies from the command line
+ *
+ * Usage:
+ *   npx tsx scripts/evaluate.ts --exact    --expected "hello world" --actual "hello world greeting"
+ *   npx tsx scripts/evaluate.ts --rouge1   --expected "machine learning" --actual "deep learning and ML" --threshold 0.5
+ *   npx tsx scripts/evaluate.ts --rougeL   --expected "natural language" --actual "NLP processing"
+ *   npx tsx scripts/evaluate.ts --bleu     --expected "the cat sat" --actual "the cat sat on the mat"
+ *   npx tsx scripts/evaluate.ts --semantic --expected "happy" --actual "joyful and content"
+ */
+
+import { performEvaluation } from '../src/lib/evaluation/evaluators/exact/exact';
+import { performRouge1Evaluation } from '../src/lib/evaluation/evaluators/rouge1-evaluator';
+import { performRougeLEvaluation } from '../src/lib/evaluation/evaluators/rougeL-evaluator';
+import { performBleuEvaluation } from '../src/lib/evaluation/evaluators/bleu/bleu-evaluator';
+import { performSemanticEvaluation } from '../src/lib/evaluation/evaluators/semantic/index';
+import { EvaluationApproach } from '../src/lib/evaluation/constants';
+import type { EvaluationRequest } from '../src/lib/evaluation/types';
+
+const APPROACHES: Record<string, EvaluationApproach> = {
+  '--exact': EvaluationApproach.EXACT,
+  '--rouge1': EvaluationApproach.ROUGE_1,
+  '--rougeL': EvaluationApproach.ROUGE_L,
+  '--bleu': EvaluationApproach.BLEU,
+  '--semantic': EvaluationApproach.SEMANTIC,
+};
+
+const EVALUATORS: Record<EvaluationApproach, (req: EvaluationRequest) => any> = {
+  [EvaluationApproach.EXACT]: performEvaluation,
+  [EvaluationApproach.ROUGE_1]: performRouge1Evaluation,
+  [EvaluationApproach.ROUGE_L]: performRougeLEvaluation,
+  [EvaluationApproach.BLEU]: performBleuEvaluation,
+  [EvaluationApproach.SEMANTIC]: performSemanticEvaluation,
+};
+
+function usage() {
+  console.error(`Usage: npx tsx scripts/evaluate.ts <strategy> --expected <string> --actual <string> [--threshold <number>]
+
+Strategies (pick one):
+  --exact      Literal keyword matching
+  --rouge1     ROUGE-1 unigram overlap (default threshold: 0.7)
+  --rougeL     ROUGE-L longest common subsequence (default threshold: 0.7)
+  --bleu       BLEU n-gram precision (default threshold: 0.7)
+  --semantic   Transformer embedding cosine similarity (default threshold: 0.7)
+
+Options:
+  --expected   Expected outcome text (keywords separated by commas or newlines)
+  --actual     Actual LLM response text
+  --threshold  Pass/fail threshold, 0-1 (optional, overrides default)
+
+Examples:
+  npx tsx scripts/evaluate.ts --exact    --expected "hello world" --actual "hello world greeting"
+  npx tsx scripts/evaluate.ts --rouge1   --expected "machine learning" --actual "deep learning and ML" --threshold 0.5
+  npx tsx scripts/evaluate.ts --semantic --expected "happy" --actual "joyful and content"`);
+}
+
+function parseArgs(argv: string[]) {
+  let expected: string | undefined;
+  let actual: string | undefined;
+  let threshold: number | undefined;
+  let approach: EvaluationApproach | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    }
+
+    if (arg in APPROACHES) {
+      if (approach) {
+        console.error(`ERROR: only one strategy allowed (got both --${approach} and ${arg})`);
+        process.exit(1);
+      }
+      approach = APPROACHES[arg];
+      continue;
+    }
+
+    if (arg === '--expected') {
+      expected = argv[++i];
+      continue;
+    }
+    if (arg === '--actual') {
+      actual = argv[++i];
+      continue;
+    }
+    if (arg === '--threshold') {
+      threshold = parseFloat(argv[++i]);
+      if (isNaN(threshold) || threshold < 0 || threshold > 1) {
+        console.error('ERROR: --threshold must be a number between 0 and 1');
+        process.exit(1);
+      }
+      continue;
+    }
+
+    console.error(`ERROR: unknown argument: ${arg}`);
+    usage();
+    process.exit(1);
+  }
+
+  if (!approach) {
+    console.error('ERROR: a strategy is required (--exact, --rouge1, --rougeL, --bleu, --semantic)');
+    usage();
+    process.exit(1);
+  }
+  if (!expected) {
+    console.error('ERROR: --expected is required');
+    process.exit(1);
+  }
+  if (!actual) {
+    console.error('ERROR: --actual is required');
+    process.exit(1);
+  }
+
+  return { approach, expected, actual, threshold };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const request: EvaluationRequest = {
+    testCaseId: 'cli',
+    question: '',
+    expectedOutcome: args.expected,
+    actualResponse: args.actual,
+    evaluationParameters: {
+      approach: args.approach,
+      ...(args.threshold !== undefined && { threshold: args.threshold }),
+    },
+  };
+
+  if (args.approach === EvaluationApproach.SEMANTIC) {
+    console.error('Loading semantic model (first run may download ~30MB)...');
+  }
+
+  const evaluate = EVALUATORS[args.approach];
+  const result = await evaluate(request);
+
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.passed ? 0 : 1);
+}
+
+main();

--- a/src/__mocks__/xenova-transformers.ts
+++ b/src/__mocks__/xenova-transformers.ts
@@ -1,0 +1,26 @@
+/**
+ * Jest mock for @xenova/transformers.
+ *
+ * @xenova/transformers v2.17.2 is pure ESM with a known __dirname
+ * redeclaration bug that makes it incompatible with Jest's CJS wrapper.
+ * The fix shipped in @huggingface/transformers v3+ (PR #809).
+ *
+ * This mock provides the minimal surface used by the semantic evaluator
+ * so that tests importing through the evaluation engine can run.
+ */
+
+export class FeatureExtractionPipeline {
+  async call() {
+    return { data: new Float32Array() };
+  }
+}
+
+export const env = {
+  useBrowserCache: false,
+  allowLocalModels: false,
+  cacheDir: '',
+};
+
+export async function pipeline() {
+  return new FeatureExtractionPipeline();
+}

--- a/src/lib/evaluation/eval-suite-runner.test.ts
+++ b/src/lib/evaluation/eval-suite-runner.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  parseEvalSuite,
+  runEvalCase,
+  runEvalSuite,
+  EvalCase,
+  EvalSuite,
+} from './eval-suite-runner';
+
+// ── parseEvalSuite ──────────────────────────────────────────────────────────
+
+describe('parseEvalSuite', () => {
+  it('should parse a valid suite JSON', () => {
+    const json = JSON.stringify({
+      suite: 'test-suite',
+      evals: [
+        {
+          id: 1,
+          actual: 'hello world',
+          expected: [{ value: 'hello', approach: 'exact' }],
+        },
+      ],
+    });
+
+    const suite = parseEvalSuite(json);
+
+    expect(suite.suite).toBe('test-suite');
+    expect(suite.evals).toHaveLength(1);
+    expect(suite.evals[0].id).toBe(1);
+  });
+
+  it('should throw on invalid JSON string', () => {
+    expect(() => parseEvalSuite('not json')).toThrow();
+  });
+
+  it('should throw on missing required fields', () => {
+    const json = JSON.stringify({ suite: 'bad' });
+    expect(() => parseEvalSuite(json)).toThrow();
+  });
+
+  it('should throw on empty evals array', () => {
+    const json = JSON.stringify({ evals: [] });
+    expect(() => parseEvalSuite(json)).toThrow();
+  });
+
+  it('should throw on invalid approach value', () => {
+    const json = JSON.stringify({
+      evals: [
+        {
+          id: 1,
+          actual: 'text',
+          expected: [{ value: 'text', approach: 'invalid-approach' }],
+        },
+      ],
+    });
+    expect(() => parseEvalSuite(json)).toThrow();
+  });
+
+  it('should allow suite name to be omitted', () => {
+    const json = JSON.stringify({
+      evals: [
+        {
+          id: 'a',
+          actual: 'text',
+          expected: [{ value: 'text', approach: 'exact' }],
+        },
+      ],
+    });
+
+    const suite = parseEvalSuite(json);
+    expect(suite.suite).toBeUndefined();
+  });
+});
+
+// ── runEvalCase ─────────────────────────────────────────────────────────────
+
+describe('runEvalCase', () => {
+  it('should pass when actual matches expected (exact)', async () => {
+    const evalCase: EvalCase = {
+      id: 'test-1',
+      actual: 'The quick brown fox jumps over the lazy dog',
+      expected: [{ value: 'quick brown fox', approach: 'exact' }],
+    };
+
+    const result = await runEvalCase(evalCase);
+
+    expect(result.passed).toBe(true);
+    expect(result.id).toBe('test-1');
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0].score).toBe(1);
+    expect(result.fields[0].keywordScores).toHaveLength(1);
+    expect(result.fields[0].keywordScores[0].keyword).toBe('quick brown fox');
+    expect(result.fields[0].keywordScores[0].passed).toBe(true);
+  });
+
+  it('should fail when actual does not match expected', async () => {
+    const evalCase: EvalCase = {
+      id: 'test-2',
+      actual: 'completely unrelated text about cooking',
+      expected: [{ value: 'quantum physics', approach: 'exact' }],
+    };
+
+    const result = await runEvalCase(evalCase);
+
+    expect(result.passed).toBe(false);
+    expect(result.fields[0].passed).toBe(false);
+    expect(result.fields[0].score).toBe(0);
+  });
+
+  it('should require all expected fields to pass', async () => {
+    const evalCase: EvalCase = {
+      id: 'test-3',
+      actual: 'machine learning is fascinating',
+      expected: [
+        { value: 'machine learning', approach: 'exact' },
+        { value: 'deep neural networks', approach: 'exact' },
+      ],
+    };
+
+    const result = await runEvalCase(evalCase);
+
+    expect(result.passed).toBe(false);
+    expect(result.fields[0].passed).toBe(true);
+    expect(result.fields[1].passed).toBe(false);
+  });
+
+  it('should pass with rouge-1 above threshold', async () => {
+    const evalCase: EvalCase = {
+      id: 'test-4',
+      actual: 'This is a language model system',
+      expected: [
+        { value: 'language model', approach: 'rouge-1', threshold: 0.5 },
+      ],
+    };
+
+    const result = await runEvalCase(evalCase);
+
+    expect(result.passed).toBe(true);
+    expect(result.fields[0].keywordScores[0].score).toBeGreaterThan(0.5);
+  });
+
+  it('should fail with rouge-1 below threshold', async () => {
+    const evalCase: EvalCase = {
+      id: 'test-5',
+      actual: 'cooking recipes for dinner',
+      expected: [
+        {
+          value: 'quantum mechanics equations',
+          approach: 'rouge-1',
+          threshold: 0.7,
+        },
+      ],
+    };
+
+    const result = await runEvalCase(evalCase);
+
+    expect(result.passed).toBe(false);
+  });
+
+  it('should use custom label when provided', async () => {
+    const evalCase: EvalCase = {
+      id: 'test-6',
+      actual: 'hello world',
+      expected: [
+        { value: 'hello', approach: 'exact', label: 'greeting-check' },
+      ],
+    };
+
+    const result = await runEvalCase(evalCase);
+
+    expect(result.fields[0].label).toBe('greeting-check');
+  });
+});
+
+// ── runEvalSuite ────────────────────────────────────────────────────────────
+
+describe('runEvalSuite', () => {
+  it('should run all evals and return aggregate results', async () => {
+    const suite: EvalSuite = {
+      suite: 'aggregate-test',
+      evals: [
+        {
+          id: 1,
+          actual: 'hello world',
+          expected: [{ value: 'hello', approach: 'exact' }],
+        },
+        {
+          id: 2,
+          actual: 'hello world',
+          expected: [{ value: 'goodbye', approach: 'exact' }],
+        },
+      ],
+    };
+
+    const result = await runEvalSuite(suite);
+
+    expect(result.total).toBe(2);
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.passRate).toBe(0.5);
+    expect(result.suite).toBe('aggregate-test');
+  });
+
+  it('should compute 100% passRate when all pass', async () => {
+    const suite: EvalSuite = {
+      evals: [
+        {
+          id: 1,
+          actual: 'hello world',
+          expected: [{ value: 'hello', approach: 'exact' }],
+        },
+        {
+          id: 2,
+          actual: 'foo bar',
+          expected: [{ value: 'foo', approach: 'exact' }],
+        },
+      ],
+    };
+
+    const result = await runEvalSuite(suite);
+
+    expect(result.passRate).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  it('should return suite name in result', async () => {
+    const suite: EvalSuite = {
+      suite: 'named-suite',
+      evals: [
+        {
+          id: 1,
+          actual: 'text',
+          expected: [{ value: 'text', approach: 'exact' }],
+        },
+      ],
+    };
+
+    const result = await runEvalSuite(suite);
+    expect(result.suite).toBe('named-suite');
+  });
+});

--- a/src/lib/evaluation/eval-suite-runner.ts
+++ b/src/lib/evaluation/eval-suite-runner.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+import { EvaluationApproach, EvaluationApproachValues } from './constants';
+import { LLMEvaluationEngine } from './evaluation-engine';
+import type { EvaluationRequestV2, EvaluationResult } from './types';
+
+// ── schemas ─────────────────────────────────────────────────────────────────
+
+const evalExpectedFieldSchema = z.object({
+  value: z.string().min(1),
+  approach: z.enum(EvaluationApproachValues as [string, ...string[]]),
+  threshold: z.number().min(0).max(1).optional(),
+  label: z.string().optional(),
+});
+
+const evalCaseSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  actual: z.string(),
+  expected: z.array(evalExpectedFieldSchema).min(1),
+});
+
+export const evalSuiteSchema = z.object({
+  suite: z.string().optional(),
+  evals: z.array(evalCaseSchema).min(1),
+});
+
+// ── types ───────────────────────────────────────────────────────────────────
+
+export type EvalExpectedField = z.infer<typeof evalExpectedFieldSchema>;
+export type EvalCase = z.infer<typeof evalCaseSchema>;
+export type EvalSuite = z.infer<typeof evalSuiteSchema>;
+
+export interface FieldResult {
+  label: string;
+  value: string;
+  approach: string;
+  passed: boolean;
+  score: number;
+  keywordScores: { keyword: string; score: number; passed: boolean }[];
+}
+
+export interface EvalCaseResult {
+  id: string | number;
+  passed: boolean;
+  fields: FieldResult[];
+  error?: string;
+}
+
+export interface EvalSuiteResult {
+  suite: string | undefined;
+  total: number;
+  passed: number;
+  failed: number;
+  passRate: number;
+  results: EvalCaseResult[];
+}
+
+// ── parsing ─────────────────────────────────────────────────────────────────
+
+export function parseEvalSuite(json: string): EvalSuite {
+  const raw = JSON.parse(json);
+  return evalSuiteSchema.parse(raw);
+}
+
+// ── single eval case ────────────────────────────────────────────────────────
+
+export async function runEvalCase(evalCase: EvalCase): Promise<EvalCaseResult> {
+  const engine = new LLMEvaluationEngine();
+
+  const request: EvaluationRequestV2 = {
+    testCaseId: String(evalCase.id),
+    question: '',
+    actualResponse: evalCase.actual,
+    fields: evalCase.expected.map((field, index) => ({
+      index,
+      label: field.label ?? `field-${index}`,
+      type: 'text' as const,
+      expectedValue: field.value,
+      evaluationParameters: {
+        approach: field.approach as EvaluationApproach,
+        ...(field.threshold !== undefined && { threshold: field.threshold }),
+      },
+    })),
+  };
+
+  return new Promise<EvalCaseResult>(resolve => {
+    engine.evaluateResponse(request, (result: EvaluationResult) => {
+      const fields: FieldResult[] = (result.fieldResults ?? []).map(fr => ({
+        label: fr.label,
+        value: fr.expectedValue,
+        approach: fr.evaluationApproachResult.approachUsed,
+        passed: fr.passed,
+        score: fr.evaluationApproachResult.score,
+        keywordScores: fr.keywordMatches.map(km => ({
+          keyword: km.keyword,
+          score: km.evaluationApproachResult.score,
+          passed: km.found,
+        })),
+      }));
+
+      resolve({
+        id: evalCase.id,
+        passed: result.passed,
+        fields,
+      });
+    });
+  });
+}
+
+// ── suite runner ────────────────────────────────────────────────────────────
+
+export async function runEvalSuite(
+  suite: EvalSuite,
+): Promise<EvalSuiteResult> {
+  const results: EvalCaseResult[] = [];
+
+  for (const evalCase of suite.evals) {
+    const result = await runEvalCase(evalCase);
+    results.push(result);
+  }
+
+  const passed = results.filter(r => r.passed).length;
+  const total = results.length;
+
+  return {
+    suite: suite.suite,
+    total,
+    passed,
+    failed: total - passed,
+    passRate: total > 0 ? passed / total : 1,
+    results,
+  };
+}

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -31,6 +31,11 @@ export const config: Config = {
   ],
   testing: {
     browserHeadless: 'shell',
+    moduleNameMapper: {
+      // @xenova/transformers v2 is pure ESM with a known __dirname bug
+      // (fixed in @huggingface/transformers v3+). Mock it for Jest/CJS compat.
+      '^@xenova/transformers$': '<rootDir>/src/__mocks__/xenova-transformers.ts',
+    },
   },
   sourceMap: true,
   globalScript: path.resolve(__dirname, 'src/global/env.ts'),


### PR DESCRIPTION
## Summary

Extracts the evaluation engine into a standalone SDK so consumers can run evals programmatically. Defines an `evals.json` contract for batch evaluation suites.

## Why

The five evaluation strategies (exact, ROUGE-1, ROUGE-L, BLEU, semantic) were inside Stencil web components. Other projects might want to import and run them as a library dependency, without mounting the UI.

## Usage

CLI single:
```sh
npx tsx scripts/evaluate.ts --rouge1 --expected "machine learning" --actual "deep learning and ML"
```

CLI batch:
```sh
npx tsx scripts/evaluate.ts --file evals.json
```

SDK:
```typescript
import { parseEvalSuite, runEvalSuite } from 'llm-testrunner-components/eval';
const results = await runEvalSuite(parseEvalSuite(json));
```

Test plan

- npx tsx scripts/evaluate.ts --exact --expected "hello" --actual "hello world"
- npx tsx scripts/evaluate.ts --file path/to/evals.json