### PR TITLE
Added and integrated copy button component for textarea

### DIFF
--- a/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
+++ b/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
@@ -187,6 +187,7 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
               ? 'Filled automatically when the test is run'
               : undefined,
             rows: field.rows || 2,
+            copyable: true,
           };
           return (
             <div class="expected-outcome-renderer__group">

--- a/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
+++ b/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
@@ -187,7 +187,7 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
               ? 'Filled automatically when the test is run'
               : undefined,
             rows: field.rows || 2,
-            copyable: true,
+            is_copyable: true,
           };
           return (
             <div class="expected-outcome-renderer__group">

--- a/src/components/llm-test-runner/test-cases/output/response-output.css
+++ b/src/components/llm-test-runner/test-cases/output/response-output.css
@@ -7,6 +7,13 @@
   flex-direction: column;
 }
 
+.response-output__toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--spacing-2);
+  min-height: var(--spacing-6);
+}
+
 .response-output__content {
   background: var(--muted);
   border: var(--border-width) solid var(--border);

--- a/src/components/llm-test-runner/test-cases/output/response-output.tsx
+++ b/src/components/llm-test-runner/test-cases/output/response-output.tsx
@@ -12,6 +12,9 @@ export const ResponseOutput: FunctionalComponent<ResponseOutputProps> = ({
 }) => {
   return (
     <div class="response-output">
+      <div class="response-output__toolbar">
+        <copy-button value={output?.text || ''} label="Copy response" />
+      </div>
       {output?.text ? (
         <div class="response-output__content">{output.text}</div>
       ) : (

--- a/src/lib/form/components/app-textarea.css
+++ b/src/lib/form/components/app-textarea.css
@@ -2,9 +2,20 @@
   margin-bottom: var(--spacing-4);
 }
 
+.textarea-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+}
+
+.textarea-label-spacer {
+  flex: 1;
+}
+
 .textarea-label {
   display: block;
-  margin-bottom: var(--spacing-2);
   font-weight: var(--font-weight-medium);
   color: var(--foreground);
   font-size: var(--font-size-sm);

--- a/src/lib/form/components/app-textarea.tsx
+++ b/src/lib/form/components/app-textarea.tsx
@@ -41,10 +41,22 @@ export class AppTextarea {
           'textarea-wrapper--read-only': !!c.readOnly,
         }}
       >
-        {c.label && (
-          <label class="textarea-label" htmlFor={c.name}>
-            {c.label}
-          </label>
+        {(c.label || c.copyable) && (
+          <div class="textarea-label-row">
+            {c.label ? (
+              <label class="textarea-label" htmlFor={c.name}>
+                {c.label}
+              </label>
+            ) : (
+              <span class="textarea-label-spacer" />
+            )}
+            {c.copyable && (
+              <copy-button
+                value={this.value}
+                label={`Copy ${c.label || 'value'}`}
+              />
+            )}
+          </div>
         )}
 
         <textarea

--- a/src/lib/form/components/app-textarea.tsx
+++ b/src/lib/form/components/app-textarea.tsx
@@ -41,7 +41,7 @@ export class AppTextarea {
           'textarea-wrapper--read-only': !!c.readOnly,
         }}
       >
-        {(c.label || c.copyable) && (
+        {(c.label || c.is_copyable) && (
           <div class="textarea-label-row">
             {c.label ? (
               <label class="textarea-label" htmlFor={c.name}>
@@ -50,7 +50,7 @@ export class AppTextarea {
             ) : (
               <span class="textarea-label-spacer" />
             )}
-            {c.copyable && (
+            {c.is_copyable && (
               <copy-button
                 value={this.value}
                 label={`Copy ${c.label || 'value'}`}

--- a/src/lib/form/schema/form-control-config.ts
+++ b/src/lib/form/schema/form-control-config.ts
@@ -8,7 +8,7 @@ export interface TextAreaConfig extends BaseInputFieldConfig {
    * When true, render an inline copy button in the label row. 
    * Always visible
    */
-  copyable?: boolean;
+  is_copyable?: boolean;
 }
 
 export interface ChipsConfig extends BaseInputFieldConfig {

--- a/src/lib/form/schema/form-control-config.ts
+++ b/src/lib/form/schema/form-control-config.ts
@@ -4,6 +4,11 @@ import { BaseInputFieldConfig } from './base-input-field-config';
 export interface TextAreaConfig extends BaseInputFieldConfig {
   fieldType: FormFieldType.TEXT_AREA;
   rows?: number;
+  /**
+   * When true, render an inline copy button in the label row. 
+   * Always visible
+   */
+  copyable?: boolean;
 }
 
 export interface ChipsConfig extends BaseInputFieldConfig {

--- a/src/lib/ui/copy-button/copy-button.css
+++ b/src/lib/ui/copy-button/copy-button.css
@@ -1,0 +1,46 @@
+:host {
+  display: inline-flex;
+  vertical-align: middle;
+}
+
+.copy-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  padding: var(--spacing-1);
+  cursor: pointer;
+  color: var(--muted-foreground);
+  border-radius: var(--radius-md);
+  transition: color 0.15s ease, transform 0.1s ease;
+  outline: none;
+  line-height: 0;
+}
+
+.copy-button:hover:not(:disabled) {
+  color: var(--info);
+}
+
+.copy-button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.copy-button:active:not(:disabled) {
+  transform: scale(0.92);
+}
+
+.copy-button:disabled {
+  cursor: default;
+}
+
+.copy-button--copied,
+.copy-button--copied:disabled {
+  color: var(--success);
+  opacity: 1;
+}
+
+.copy-button svg {
+  display: block;
+}

--- a/src/lib/ui/copy-button/copy-button.spec.tsx
+++ b/src/lib/ui/copy-button/copy-button.spec.tsx
@@ -21,8 +21,6 @@ function getCopyIcon(page: SpecPage): SVGRectElement | null {
 }
 
 function isDisabled(button: HTMLButtonElement): boolean {
-  // Stencil's spec-mode mock DOM doesn't reflect the .disabled property,
-  // so check the attribute instead.
   return button.hasAttribute('disabled');
 }
 
@@ -35,8 +33,6 @@ async function clickAndSettle(
   button: HTMLButtonElement,
 ): Promise<void> {
   button.click();
-  // Flush microtasks so `await navigator.clipboard.writeText(...)` resolves
-  // and the handler reaches `this.copied = true`.
   await Promise.resolve();
   await Promise.resolve();
   await page.waitForChanges();
@@ -51,19 +47,25 @@ function setClipboardImpl(
   writeTextMock.mockImplementation(impl);
 }
 
+let originalNavigatorDescriptor: PropertyDescriptor | undefined;
+
 beforeEach(() => {
   setClipboardImpl();
-  // Attach (or replace) navigator.clipboard with our spy.
-  Object.defineProperty(navigator, 'clipboard', {
+  originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(global, 'navigator');
+  Object.defineProperty(global as any, 'navigator', {
     configurable: true,
-    value: { writeText: writeTextMock },
+    writable: true,
+    value: { clipboard: { writeText: writeTextMock } },
   });
 });
 
 afterEach(() => {
-  // Clean up any pending real-timers so a stray setTimeout (the 1.4s reset
-  // from a prior test) doesn't fire into a later test's component.
   jest.clearAllTimers();
+  if (originalNavigatorDescriptor) {
+    Object.defineProperty(global as any, 'navigator', originalNavigatorDescriptor);
+  } else {
+    delete (global as { navigator?: unknown }).navigator;
+  }
 });
 
 describe('CopyButton', () => {
@@ -134,9 +136,6 @@ describe('CopyButton', () => {
 
     await clickAndSettle(page, getButton(page));
     expect(getButton(page).className).toContain('copy-button--copied');
-
-    // Use a real (short) timeout so we don't have to coordinate fake timers
-    // with the async click handler's awaited Promises.
     await new Promise<void>((resolve) => setTimeout(resolve, 40));
     await page.waitForChanges();
 

--- a/src/lib/ui/copy-button/copy-button.spec.tsx
+++ b/src/lib/ui/copy-button/copy-button.spec.tsx
@@ -1,0 +1,189 @@
+import { jest, describe, beforeEach, afterEach, it, expect } from '@jest/globals';
+import { newSpecPage } from '@stencil/core/testing';
+import { CopyButton } from './copy-button';
+
+type SpecPage = Awaited<ReturnType<typeof newSpecPage>>;
+
+function getButton(page: SpecPage): HTMLButtonElement {
+  return page.root!.shadowRoot!.querySelector('.copy-button') as HTMLButtonElement;
+}
+
+function getCheckIcon(page: SpecPage): SVGPolylineElement | null {
+  return page.root!.shadowRoot!.querySelector(
+    '.copy-button polyline',
+  ) as SVGPolylineElement | null;
+}
+
+function getCopyIcon(page: SpecPage): SVGRectElement | null {
+  return page.root!.shadowRoot!.querySelector(
+    '.copy-button rect',
+  ) as SVGRectElement | null;
+}
+
+function isDisabled(button: HTMLButtonElement): boolean {
+  // Stencil's spec-mode mock DOM doesn't reflect the .disabled property,
+  // so check the attribute instead.
+  return button.hasAttribute('disabled');
+}
+
+/**
+ * Click + wait for the async click handler's awaited promises AND the
+ * subsequent re-render to settle.
+ */
+async function clickAndSettle(
+  page: SpecPage,
+  button: HTMLButtonElement,
+): Promise<void> {
+  button.click();
+  // Flush microtasks so `await navigator.clipboard.writeText(...)` resolves
+  // and the handler reaches `this.copied = true`.
+  await Promise.resolve();
+  await Promise.resolve();
+  await page.waitForChanges();
+}
+
+const writeTextMock = jest.fn<(value: string) => Promise<void>>();
+
+function setClipboardImpl(
+  impl: (value: string) => Promise<void> = () => Promise.resolve(),
+): void {
+  writeTextMock.mockReset();
+  writeTextMock.mockImplementation(impl);
+}
+
+beforeEach(() => {
+  setClipboardImpl();
+  // Attach (or replace) navigator.clipboard with our spy.
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText: writeTextMock },
+  });
+});
+
+afterEach(() => {
+  // Clean up any pending real-timers so a stray setTimeout (the 1.4s reset
+  // from a prior test) doesn't fire into a later test's component.
+  jest.clearAllTimers();
+});
+
+describe('CopyButton', () => {
+  it('renders the copy icon and is enabled when a value is provided', async () => {
+    const page = await newSpecPage({
+      components: [CopyButton],
+      html: '<copy-button value="hello"></copy-button>',
+    });
+
+    const button = getButton(page);
+    expect(button).not.toBeNull();
+    expect(isDisabled(button)).toBe(false);
+    expect(getCopyIcon(page)).not.toBeNull();
+    expect(getCheckIcon(page)).toBeNull();
+  });
+
+  it('is disabled when the value is empty', async () => {
+    const page = await newSpecPage({
+      components: [CopyButton],
+      html: '<copy-button value=""></copy-button>',
+    });
+
+    expect(isDisabled(getButton(page))).toBe(true);
+  });
+
+  it('is disabled when no value attribute is provided', async () => {
+    const page = await newSpecPage({
+      components: [CopyButton],
+      html: '<copy-button></copy-button>',
+    });
+
+    expect(isDisabled(getButton(page))).toBe(true);
+  });
+
+  it('writes the value to the clipboard on click', async () => {
+    const page = await newSpecPage({
+      components: [CopyButton],
+      html: '<copy-button value="payload"></copy-button>',
+    });
+
+    await clickAndSettle(page, getButton(page));
+
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    expect(writeTextMock).toHaveBeenCalledWith('payload');
+  });
+
+  it('flips to the green tick and disables itself after a successful copy', async () => {
+    const page = await newSpecPage({
+      components: [CopyButton],
+      html: '<copy-button value="payload"></copy-button>',
+    });
+
+    await clickAndSettle(page, getButton(page));
+
+    const button = getButton(page);
+    expect(isDisabled(button)).toBe(true);
+    expect(button.className).toContain('copy-button--copied');
+    expect(getCheckIcon(page)).not.toBeNull();
+    expect(getCopyIcon(page)).toBeNull();
+    expect(button.getAttribute('title')).toBe('Copied');
+  });
+
+  it('resets to the copy icon after the configured timeout', async () => {
+    const page = await newSpecPage({
+      components: [CopyButton],
+      html: '<copy-button value="payload" reset-ms="20"></copy-button>',
+    });
+
+    await clickAndSettle(page, getButton(page));
+    expect(getButton(page).className).toContain('copy-button--copied');
+
+    // Use a real (short) timeout so we don't have to coordinate fake timers
+    // with the async click handler's awaited Promises.
+    await new Promise<void>((resolve) => setTimeout(resolve, 40));
+    await page.waitForChanges();
+
+    const button = getButton(page);
+    expect(button.className).not.toContain('copy-button--copied');
+    expect(isDisabled(button)).toBe(false);
+    expect(getCopyIcon(page)).not.toBeNull();
+    expect(getCheckIcon(page)).toBeNull();
+  });
+
+  it('does not copy again while in the copied state', async () => {
+    const page = await newSpecPage({
+      components: [CopyButton],
+      html: '<copy-button value="payload"></copy-button>',
+    });
+
+    await clickAndSettle(page, getButton(page));
+    await clickAndSettle(page, getButton(page));
+    await clickAndSettle(page, getButton(page));
+
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not enter the copied state when the clipboard write fails', async () => {
+    setClipboardImpl(() => Promise.reject(new Error('blocked')));
+
+    const page = await newSpecPage({
+      components: [CopyButton],
+      html: '<copy-button value="payload"></copy-button>',
+    });
+
+    await clickAndSettle(page, getButton(page));
+
+    const button = getButton(page);
+    expect(button.className).not.toContain('copy-button--copied');
+    expect(isDisabled(button)).toBe(false);
+    expect(getCopyIcon(page)).not.toBeNull();
+  });
+
+  it('uses the provided label as the idle tooltip', async () => {
+    const page = await newSpecPage({
+      components: [CopyButton],
+      html: '<copy-button value="payload" label="Copy response"></copy-button>',
+    });
+
+    const button = getButton(page);
+    expect(button.getAttribute('title')).toBe('Copy response');
+    expect(button.getAttribute('aria-label')).toBe('Copy response');
+  });
+});

--- a/src/lib/ui/copy-button/copy-button.tsx
+++ b/src/lib/ui/copy-button/copy-button.tsx
@@ -1,0 +1,111 @@
+import { Component, Prop, State, h } from '@stencil/core';
+
+export interface CopyButtonProps {
+  value?: string;
+  label?: string;
+  resetMs?: number;
+}
+
+@Component({
+  tag: 'copy-button',
+  styleUrl: 'copy-button.css',
+  shadow: true,
+})
+export class CopyButton implements CopyButtonProps {
+  /**
+   * If empty/undefined, the button is rendered in a disabled state.
+   */
+  @Prop() value?: string = '';
+  @Prop() label?: string = 'Copy';
+  @Prop() resetMs?: number = 1400;
+
+  @State() copied = false;
+
+  private timeoutId?: number;
+
+  disconnectedCallback() {
+    if (this.timeoutId !== undefined) {
+      window.clearTimeout(this.timeoutId);
+      this.timeoutId = undefined;
+    }
+  }
+
+  private handleClick = async (): Promise<void> => {
+    if (this.copied || !this.value) return;
+
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(this.value);
+      } else {
+        return;
+      }
+    } catch {
+      return;
+    }
+
+    this.copied = true;
+    if (this.timeoutId !== undefined) {
+      window.clearTimeout(this.timeoutId);
+    }
+    this.timeoutId = window.setTimeout(() => {
+      this.copied = false;
+      this.timeoutId = undefined;
+    }, this.resetMs);
+  };
+
+  render() {
+    const hasValue = !!this.value;
+    const disabled = !hasValue || this.copied;
+    const title = this.copied 
+      ? 'Copied'
+      : hasValue
+        ? this.label
+        : '';
+
+    return (
+      <button
+        type="button"
+        class={{
+          'copy-button': true,
+          'copy-button--copied': this.copied,
+        }}
+        onClick={this.handleClick}
+        disabled={disabled}
+        title={title}
+        aria-label={title}
+        aria-live="polite"
+      >
+        {this.copied ? (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <polyline points="20 6 9 17 4 12"></polyline>
+          </svg>
+        ) : (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="9" y="9" width="13" height="13" rx="2"></rect>
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+          </svg>
+        )}
+      </button>
+    );
+  }
+}

--- a/src/lib/ui/copy-button/copy-button.tsx
+++ b/src/lib/ui/copy-button/copy-button.tsx
@@ -17,7 +17,7 @@ export class CopyButton implements CopyButtonProps {
    */
   @Prop() value?: string = '';
   @Prop() label?: string = 'Copy';
-  @Prop() resetMs?: number = 1400;
+  @Prop() resetMs?: number = 500;
 
   @State() copied = false;
 

--- a/src/lib/ui/copy-button/index.ts
+++ b/src/lib/ui/copy-button/index.ts
@@ -1,0 +1,2 @@
+export { CopyButton } from './copy-button';
+export type { CopyButtonProps } from './copy-button';


### PR DESCRIPTION
Adds one-click copy buttons to the Expected Outcome label row (visible in both static and dynamic outcome modes) and the Output column.

Reason being in outcomeMode: dynamic the Expected Outcome textarea is read-only, leaving no easy way to grab the resolved value. The Output response can be large too.

Changes Added:
1. New shared Stencil component <copy-button> (icon-only, hover blue, green-tick + disabled for for sometime after copy, accessible title / aria-label / aria-live).
2. New opt-in copyable flag on TextAreaConfig: app-textarea renders the copy-button in the label row when set.

<img width="1165" height="480" alt="Screenshot 2026-04-27 at 7 13 15 PM" src="https://github.com/user-attachments/assets/73314d1b-e8ac-48e2-a7af-ee36577c9b31" />
