### PR TITLE
Fixed CSS to prevent horizontal column distortion on large unbroken text

### DIFF
--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.css
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.css
@@ -7,6 +7,15 @@
   min-height: 200px;
 }
 
+/*
+ * Grid items default to min-width: auto, which prevents tracks from
+ * shrinking below their content's min-content width. Force 0 so long
+ * unbreakable strings (e.g. JSON dumps) don't blow out the layout.
+ */
+.test-case-row > * {
+  min-width: 0;
+}
+
 .test-case-row:hover {
   background: var(--muted);
 }

--- a/src/components/llm-test-runner/test-cases/output/response-output.css
+++ b/src/components/llm-test-runner/test-cases/output/response-output.css
@@ -16,11 +16,12 @@
   line-height: var(--line-height-relaxed);
   color: var(--foreground);
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: anywhere; /* Allow breaking long words/base64 */
   flex: 1;
   overflow-y: auto;
   max-height: 250px;
   overflow-x: scroll;
+  min-width: 0;
 }
 
 .response-output__placeholder {
@@ -33,6 +34,7 @@
   background: var(--muted);
   border: 2px dashed var(--border);
   border-radius: var(--radius);
+  min-width: 0;
 }
 
 /* Responsive Design */


### PR DESCRIPTION
Grid items default to min-width: auto, which prevents a track from shrinking below its content's min-content size. 
For large text(JSON strings) with no whitespace, min-content equals the entire string — so the Output track was expanding past its 1.5fr share and pushing the rest of the columns out of place. 
Fixed css by adding two changes:
1. `llm-test-case-row.css` : 
        - Added `.test-case-row > * { min-width: 0; }` so every grid track can shrink below its content's intrinsic width.

2. `response-output.css`: 
        - `min-width: 0` on `.response-output__content` and `.response-output__placeholder` 
        - Replaced `word-wrap: break-word` with `overflow-wrap: anywhere` so the engine breaks long unbreakable strings instead of declining when it can't find a "natural" break point.


Bug:
<img width="1262" height="460" alt="image" src="https://github.com/user-attachments/assets/81bcc85a-17db-4ed4-9ded-82891cb2e9c6" />


With CSS Fix:
<img width="1188" height="472" alt="image" src="https://github.com/user-attachments/assets/e9128174-132d-4bfb-ab15-d901dc7a87f3" />

