### PR TITLE
Fixed CSS and showing inprogress text  on test re-run

### DIFF
--- a/src/components/llm-test-runner/llm-test-runner.css
+++ b/src/components/llm-test-runner/llm-test-runner.css
@@ -29,3 +29,19 @@
 .test-runner-container__content {
   padding: 0;
 }
+
+@keyframes placeholder-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes placeholder-dots {
+  to {
+    width: 1.2em;
+  }
+}

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -211,7 +211,16 @@ export class LLMTestRunner {
 
   private async runSingleTest(testCase: TestCase): Promise<void> {
     const startTime = Date.now();
-    this.updateTestCase(testCase.id, { isRunning: true });
+    // Clear results from any previous run so the Output and Evaluation
+    // columns show "Running..." / "Evaluating..." placeholders instead
+    // of stale content from the prior run.
+    this.updateTestCase(testCase.id, {
+      isRunning: true,
+      output: undefined,
+      evaluationResult: undefined,
+      error: null,
+      responseTime: undefined,
+    });
     const [llmSettled, resolutionSettled] = await Promise.allSettled([
       this.requestLlmResponse(testCase),
       resolveDynamicExpectedOutcomes(testCase, this.resolveExpectedOutcome),

--- a/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.css
+++ b/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.css
@@ -94,6 +94,19 @@
   border-radius: var(--radius);
 }
 
+.evaluation-summary__placeholder--running {
+  animation: placeholder-pulse 1.6s ease-in-out infinite;
+}
+
+.evaluation-summary__placeholder-text::after {
+  content: '...';
+  display: inline-block;
+  width: 0;
+  overflow: hidden;
+  vertical-align: bottom;
+  animation: placeholder-dots 1.4s steps(4) infinite;
+}
+
 /* Evaluation Result Element */
 .evaluation-summary__result {
   display: flex;

--- a/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.tsx
+++ b/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.tsx
@@ -63,8 +63,15 @@ export const EvaluationSummary: FunctionalComponent<EvaluationSummaryProps> = ({
           ) : null}
         </div>
       ) : (
-        <div class="evaluation-summary__placeholder">
-          {isRunning ? 'Evaluating...' : ''}
+        <div
+          class={{
+            'evaluation-summary__placeholder': true,
+            'evaluation-summary__placeholder--running': isRunning,
+          }}
+        >
+          {isRunning && (
+            <span class="evaluation-summary__placeholder-text">Evaluating</span>
+          )}
         </div>
       )}
     </div>

--- a/src/components/llm-test-runner/test-cases/output/response-output.css
+++ b/src/components/llm-test-runner/test-cases/output/response-output.css
@@ -44,6 +44,19 @@
   min-width: 0;
 }
 
+.response-output__placeholder--running {
+  animation: placeholder-pulse 1.6s ease-in-out infinite;
+}
+
+.response-output__placeholder-text::after {
+  content: '...';
+  display: inline-block;
+  width: 0;
+  overflow: hidden;
+  vertical-align: bottom;
+  animation: placeholder-dots 1.4s steps(4) infinite;
+}
+
 /* Responsive Design */
 @media (max-width: 1200px) {
   .response-output {

--- a/src/components/llm-test-runner/test-cases/output/response-output.tsx
+++ b/src/components/llm-test-runner/test-cases/output/response-output.tsx
@@ -18,7 +18,16 @@ export const ResponseOutput: FunctionalComponent<ResponseOutputProps> = ({
       {output?.text ? (
         <div class="response-output__content">{output.text}</div>
       ) : (
-        <div class="response-output__placeholder">{isRunning ? 'Running...' : ''}</div>
+        <div
+          class={{
+            'response-output__placeholder': true,
+            'response-output__placeholder--running': isRunning,
+          }}
+        >
+          {isRunning && (
+            <span class="response-output__placeholder-text">Running</span>
+          )}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
When a user re-runs an already-completed test case, the Output and evaluation column keeps showing the previous run's response while the new run is in flight.
Fixed the issue by resetting data on every re-run, and also added basic animation for good UX


https://github.com/user-attachments/assets/fd1af073-d091-4d72-8555-2222f0734687

