### PR TITLE
Add LLM-as-judge as an evaluation approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LLM TestRunner Components
 
-**A ready-made UI for testing your LLM.** Add questions and expected outcomes, run tests one-by-one or in batch, and get pass/fail results using five evaluation strategies—while you keep full control over which LLM you call (OpenAI, Gemini, Claude, or your own).
+**A ready-made UI for testing your LLM.** Add questions and expected outcomes, run tests one-by-one or in batch, and get pass/fail results using six evaluation strategies—while you keep full control over which LLM you call (OpenAI, Gemini, Claude, or your own).
 
 [![npm](https://img.shields.io/npm/v/llm-testrunner-components.svg)](https://www.npmjs.com/package/llm-testrunner-components) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -10,14 +10,14 @@
 
 - **Test faster** — You get a complete test-runner UI (questions, expected outcomes, run one / run all, pass/fail, response times). No need to build tables, evaluation logic, or import/export from scratch.
 - **Stay in control** — The library never calls an LLM. You handle one event: we send you the prompt, you call your API and pass back the response (or an error). Works with any provider or local model.
-- **Match how you think** — Each expected-outcome field can use a different evaluation: exact keywords, semantic similarity (meaning), ROUGE (word overlap / sequence), or BLEU (n-gram precision). Choose per field.
+- **Match how you think** — Each expected-outcome field can use a different evaluation: exact keywords, semantic similarity (meaning), ROUGE (word overlap / sequence), BLEU (n-gram precision), or LLM-as-judge (criterion-based grading by another LLM). Choose per field.
 - **Fit your stack** — Load test cases from your backend or a JSON file. Optionally persist runs with a Save button that emits the current state so you can store it in Firebase, your API, or anywhere else.
 
 ---
 
 ## What you get
 
-- **Test case table** — Add, edit, delete test cases. Each test case has a question, configurable expected-outcome fields (single line, paragraph, keyword chips, dropdown), and a per-field evaluation approach (exact, semantic, ROUGE-1, ROUGE-L, BLEU).
+- **Test case table** — Add, edit, delete test cases. Each test case has a question, configurable expected-outcome fields (single line, paragraph, keyword chips, dropdown), and a per-field evaluation approach (exact, semantic, ROUGE-1, ROUGE-L, BLEU, llm-judge).
 - **Run one or run all** — Run a single test or batch with a configurable delay between API calls (rate limiting).
 - **Live results** — Pass/fail, keyword match count (e.g. X/Y found), and response time per test.
 - **Import / export** — Import a test suite from JSON. Export the current suite as JSON or export run results as CSV.
@@ -110,13 +110,56 @@ Load the loader and define the custom elements, then listen for `llmRequest` and
 
 ## Connect your LLM
 
-The library **never** sends requests to an LLM. You do. When a test runs, the component emits an `llmRequest` event with:
+The library **never** sends requests to an LLM. You do.
 
-- `prompt` — the question text for this test case  
-- `resolve({ text, metadata? })` — call this with the model’s reply payload  
-- `reject(error)` — call this if the request fails  
+**For the model under test** — when a test runs, the component emits an `llmRequest` event with:
 
-How you get the response is up to you: REST, SDK, or local inference. Same pattern for OpenAI, Gemini, Claude, or any other provider.
+- `prompt` — the question text for this test case
+- `resolve({ text, metadata? })` — call this with the model’s reply payload
+- `reject(error)` — call this if the request fails
+
+**For LLM-as-judge evaluation** — if any field uses the `llm-judge` approach, you must also provide an `llmJudge` callback. The library hands you the prompt messages and expects you to call your model and return parsed JSON:
+
+```ts
+runner.llmJudge = async ({ messages }) => {
+  // messages: [{ role: "system", content: ... }, { role: "user", content: ... }]
+  const raw = await yourLLMApi(messages);
+  return JSON.parse(raw); // must match { criteria: [{ id, score, reason? }] }
+};
+```
+
+**Why the format matters**
+
+Keep the two messages separate — the system message carries the JSON contract and grading rubric, and providers weight it more heavily than user content. Collapsing both into one prompt makes the judge more likely to drift or wrap output in markdown.
+
+The output is validated, not parsed-and-hoped. A wrong shape, scores outside `[0, 1]`, or missing scores for criteria you supplied all surface as a per-field error — not a low score. Set temperature low (e.g. `0`) for reproducible grading.
+
+**Worked example (Gemini)**
+
+```ts
+import { GoogleGenAI } from "@google/genai";
+
+const genai = new GoogleGenAI({ apiKey: process.env.GEMINI_KEY });
+
+runner.llmJudge = async ({ messages }) => {
+  const system = messages.find((m) => m.role === "system")?.content;
+  const user = messages.find((m) => m.role === "user")!.content;
+
+  const response = await genai.models.generateContent({
+    model: "gemini-3-flash-preview",
+    contents: user,
+    config: { systemInstruction: system },
+  });
+
+  // Gemini sometimes wraps JSON in ```json ... ``` despite the prompt's instructions.
+  const stripped = response.text
+    .trim()
+    .replace(/^```(?:json)?\s*([\s\S]*?)\s*```$/, "$1");
+  return JSON.parse(stripped);
+};
+```
+
+How you get either response is up to you: REST, SDK, or local inference. Same pattern for OpenAI, Gemini, Claude, or any other provider.
 
 ---
 
@@ -139,11 +182,14 @@ Each expected-outcome field can use a different evaluation method. All of them c
 | **ROUGE-L** | Longest common subsequence   | Phrasing and word order matter                 | Moderate–high            | Slightly slower |
 | **Semantic** | Meaning (embeddings + cosine) | Different words, same meaning                 | Yes                      | First run loads model |
 | **BLEU**  | N-gram precision (1–4)         | Translation-like or n-gram overlap             | Moderate                 | Fast         |
+| **LLM-judge** | Criterion-by-criterion grading by another LLM | Open-ended answers, rubrics, qualitative checks | Yes              | Slow (extra API call per test) |
 
 - Set **per expected-outcome field** via the dropdown in the UI, or via each field’s `evaluationParameters.approach` when you pass `initialTestCases`.
 - **ROUGE, BLEU, and Semantic** use a default threshold (0.7). Override per field via the **Threshold** input under "More options" in the UI, or by
   setting `evaluationParameters.threshold` (a number in `[0, 1]`) on the field when you pass `initialTestCases`.
 - **Semantic** uses in-browser embeddings ([Xenova/all-MiniLM-L6-v2](https://huggingface.co/Xenova/all-MiniLM-L6-v2)). The first time you use it, the model is downloaded; later runs are faster.
+- **LLM-judge** requires you to provide a second callback (`llmJudge`) that calls an LLM to score the response. The library never calls an LLM directly — see [Connect your LLM](#connect-your-llm). Define grading criteria per field via `evaluationParameters.criteria` (each criterion has `id`, `description`, and optional `weight` — see [Types](#types)). If you omit criteria, a single `correctness` criterion is used. Default pass threshold is `0.7`.
+- The judge callback must return JSON in the shape `{ criteria: [{ id, score, reason? }] }` with one entry per criterion you supplied. Scores are in `[0, 1]`. The library validates this and surfaces a per-field error if the shape is wrong.
 
 ---
 
@@ -171,6 +217,7 @@ When you pass `initialTestCases`, use an array of objects with `type`, `label`, 
 | `initialTestCases` | — | `TestCase[]` | `undefined` | Preload test cases. See [types](#types) below. |
 | `defaultExpectedOutcomeSchema` | — | `ExpectedOutcomeSchema` | built-in | Schema for new test cases (field types and labels). |
 | `evaluationSourceExtractors` | — | `EvaluationSourceExtractors` | `undefined` | Registry of named extractors used by per-field `evaluationSource: { type: 'custom', extractorId }`. |
+| `llmJudge` | — | `LlmJudge` | `undefined` | Callback the runner invokes for every field with `approach: 'llm-judge'`. Receives `{ messages }`, must return `{ criteria: [{ id, score, reason? }] }`. Required if any field uses `llm-judge`. |
 
 ### Events
 
@@ -200,6 +247,10 @@ import type {
   ExpectedOutcomeSchema,
   ExpectedOutcomeField,
   EvaluationParameters,
+  Criterion,
+  JudgeMessage,
+  JudgeResponse,
+  LlmJudge,
 } from "llm-testrunner-components/react/types";
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-testrunner-components",
-  "version": "1.3.4",
+  "version": "1.3.5-internal.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-testrunner-components",
-      "version": "1.3.4",
+      "version": "1.3.5-internal.0",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.40.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1922,9 +1922,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -1950,9 +1950,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1968,9 +1968,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
@@ -3069,13 +3069,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -3347,9 +3347,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5872,9 +5872,9 @@
       "license": "MIT"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8473,22 +8473,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-testrunner-components",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-testrunner-components",
-      "version": "1.3.5",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.40.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-testrunner-components",
-  "version": "1.3.4",
+  "version": "1.3.5-internal.0",
   "description": "A Stencil web component library for LLM test runner functionality",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "build:react": "tsc --project tsconfig.react.json",
     "watch:react-wrapper": "nodemon --watch generated/react --ext ts,tsx --exec \"npm run build:react\"",
     "build:all": "npm run build && npm run build:react",
+    "prepare": "npm run build:all",
     "build-publish": "npm run build:all && npm run just-publish",
     "just-publish": "npm publish --access=public",
     "lint": "eslint src --ext .ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-testrunner-components",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "A Stencil web component library for LLM test runner functionality",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -17,6 +17,7 @@ import {
   SavePayload,
   ModelResponsePayload,
   EvaluationSourceExtractors,
+  LlmJudge,
 } from '../../types/llm-test-runner';
 import { readFileAsync } from '../../lib/file/file-reader';
 import { downloadFile } from '../../lib/file/file-download';
@@ -72,6 +73,7 @@ export class LLMTestRunner {
   @Prop() evaluationSourceExtractors?: EvaluationSourceExtractors;
   @Prop() initialTestCases?: TestCase[];
   @Prop() defaultExpectedOutcomeSchema?: ExpectedOutcomeSchema;
+  @Prop() llmJudge?: LlmJudge;
   @State() testCases: TestCase[] = [
     {
       id: '1',
@@ -288,6 +290,7 @@ export class LLMTestRunner {
         });
       },
       this.evaluationSourceExtractors,
+      this.llmJudge,
     );
   }
 

--- a/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.css
+++ b/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.css
@@ -103,19 +103,29 @@
   gap: 2px;
 }
 
+/* Grid layout (1fr | auto) so the id column can shrink when it's long,
+ * triggering the ellipsis below — the score column stays its natural
+ * width on the right. */
 .evaluation-summary__criterion-item {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
+  gap: var(--spacing-2);
   font-size: var(--font-size-xs);
+  line-height: 1.3;
 }
 
 .evaluation-summary__criterion-id {
   font-family: var(--font-family-mono, ui-monospace, "SF Mono", Menlo, monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .evaluation-summary__criterion-score {
-  margin-left: auto;
   font-variant-numeric: tabular-nums;
+  text-align: right;
 }
 
 /* Evaluation Result Element */

--- a/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.css
+++ b/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.css
@@ -94,6 +94,30 @@
   border-radius: var(--radius);
 }
 
+.evaluation-summary__criterion-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.evaluation-summary__criterion-item {
+  display: flex;
+  align-items: center;
+  font-size: var(--font-size-xs);
+}
+
+.evaluation-summary__criterion-id {
+  font-family: var(--font-family-mono, ui-monospace, "SF Mono", Menlo, monospace);
+}
+
+.evaluation-summary__criterion-score {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Evaluation Result Element */
 .evaluation-summary__result {
   display: flex;

--- a/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.tsx
+++ b/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.tsx
@@ -56,6 +56,21 @@ export const EvaluationSummary: FunctionalComponent<EvaluationSummaryProps> = ({
                       {fieldResult.keywordMatches.filter(match => match.found).length}/
                       {fieldResult.keywordMatches.length}
                     </span>
+                    {fieldResult.criterionResults &&
+                      fieldResult.criterionResults.length > 0 && (
+                        <ul class="evaluation-summary__criterion-list">
+                          {fieldResult.criterionResults.map(criterion => (
+                            <li class="evaluation-summary__criterion-item">
+                              <span class="evaluation-summary__criterion-id">
+                                {criterion.id}
+                              </span>
+                              <span class="evaluation-summary__criterion-score">
+                                {criterion.score.toFixed(2)}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
                   </div>
                 </div>
               ))}

--- a/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.tsx
+++ b/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.tsx
@@ -61,7 +61,10 @@ export const EvaluationSummary: FunctionalComponent<EvaluationSummaryProps> = ({
                         <ul class="evaluation-summary__criterion-list">
                           {fieldResult.criterionResults.map(criterion => (
                             <li class="evaluation-summary__criterion-item">
-                              <span class="evaluation-summary__criterion-id">
+                              <span
+                                class="evaluation-summary__criterion-id"
+                                title={criterion.id}
+                              >
                                 {criterion.id}
                               </span>
                               <span class="evaluation-summary__criterion-score">

--- a/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
+++ b/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
@@ -187,6 +187,28 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
     );
   };
 
+  const renderCriteriaInput = (
+    field: ExpectedOutcomeField,
+    index: number,
+  ) => {
+    if (field.evaluationParameters?.approach !== EvaluationApproach.LLM_JUDGE) {
+      return null;
+    }
+    return (
+      <criteria-input
+        criteria={field.evaluationParameters?.criteria}
+        onCriteriaChange={(e) =>
+          emit({
+            testCaseId,
+            index,
+            operation: 'set-evaluation-criteria',
+            value: e.detail.value,
+          })
+        }
+      />
+    );
+  };
+
   const renderEvaluationOptions = (field: ExpectedOutcomeField, index: number) => (
     <details class="expected-outcome-renderer__options">
       <summary class="expected-outcome-renderer__options-summary">
@@ -196,6 +218,7 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
         {renderEvaluationSelector(field, index)}
         {renderThresholdInput(field, index)}
         {renderEvaluationSourceSelector(field, index)}
+        {renderCriteriaInput(field, index)}
       </div>
     </details>
   );

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.css
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.css
@@ -61,7 +61,7 @@
 .expected-outcome-renderer__options-content {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: var(--spacing-2);
   padding: 0 var(--spacing-3) var(--spacing-3);
 }
 

--- a/src/demo/demo-modes.js
+++ b/src/demo/demo-modes.js
@@ -98,6 +98,59 @@ export const DEMO_MODES = {
       },
     ],
   },
+  llmJudge: {
+    initialTestCases: [
+      {
+        id: 'demo-llmJudge-1',
+        question:
+          'In one or two sentences, explain why the sky appears blue during the day.',
+        expectedOutcome: [
+          {
+            type: 'textarea',
+            label: 'Expected Outcome',
+            value:
+              'Sunlight is scattered by air molecules; shorter (blue) wavelengths scatter more, so the sky looks blue.',
+            evaluationParameters: {
+              approach: 'llm-judge',
+              threshold: 0.7,
+              criteria: [
+                {
+                  id: 'correctness',
+                  description:
+                    'Names Rayleigh scattering or describes shorter/blue wavelengths scattering more.',
+                  weight: 2,
+                },
+                {
+                  id: 'concision',
+                  description:
+                    'Stays within roughly one to two sentences and avoids unrelated tangents.',
+                  weight: 1,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: 'demo-llmJudge-2',
+        question:
+          'Briefly: what is one upside and one downside of using LLM-as-judge?',
+        expectedOutcome: [
+          {
+            type: 'textarea',
+            label: 'Expected Outcome',
+            value:
+              'Upside: scales beyond hand-graded keyword matching for open-ended outputs. Downside: judges can be biased and add cost / latency.',
+            evaluationParameters: {
+              approach: 'llm-judge',
+              threshold: 0.7,
+              // No criteria — falls back to the default correctness criterion.
+            },
+          },
+        ],
+      },
+    ],
+  },
   dynamicExpectedOutcome: {
     initialTestCases: [
       {

--- a/src/demo/vanilla-demo.js
+++ b/src/demo/vanilla-demo.js
@@ -14,6 +14,34 @@ function wireGemini(runner) {
   });
 }
 
+/**
+ * Strips ```json ... ``` (or plain ```) fences a model often wraps JSON in.
+ * Used in the demo because Gemini responses sometimes include them despite
+ * the prompt's "no markdown" rule.
+ */
+function stripJsonFence(raw) {
+  const trimmed = String(raw).trim();
+  const fence = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  return fence ? fence[1] : trimmed;
+}
+
+/**
+ * Wires the `<llm-test-runner llmJudge>` prop to Gemini. The library passes
+ * a `{messages: [{role, content}, …]}` payload — we flatten to a single
+ * prompt (Gemini's `invoke` takes one string), parse the JSON response, and
+ * return the `JudgeResponse` shape the library expects.
+ */
+function wireGeminiJudge(runner) {
+  const llm = new window.GeminiAdapter(window.env.API_KEY);
+  runner.llmJudge = async ({ messages }) => {
+    const prompt = messages
+      .map((m) => `[${m.role.toUpperCase()}]\n${m.content}`)
+      .join('\n\n');
+    const raw = await llm.invoke(prompt);
+    return JSON.parse(stripJsonFence(raw));
+  };
+}
+
 function mountMode(host, modeKey) {
   const config = DEMO_MODES[modeKey];
   host.replaceChildren();
@@ -28,6 +56,7 @@ function mountMode(host, modeKey) {
   }
   host.appendChild(runner);
   wireGemini(runner);
+  wireGeminiJudge(runner);
 }
 
 function initVanillaDemo() {

--- a/src/demo/vanilla-demo.js
+++ b/src/demo/vanilla-demo.js
@@ -25,19 +25,18 @@ function stripJsonFence(raw) {
   return fence ? fence[1] : trimmed;
 }
 
-/**
- * Wires the `<llm-test-runner llmJudge>` prop to Gemini. The library passes
- * a `{messages: [{role, content}, …]}` payload — we flatten to a single
- * prompt (Gemini's `invoke` takes one string), parse the JSON response, and
- * return the `JudgeResponse` shape the library expects.
- */
 function wireGeminiJudge(runner) {
   const llm = new window.GeminiAdapter(window.env.API_KEY);
   runner.llmJudge = async ({ messages }) => {
-    const prompt = messages
-      .map((m) => `[${m.role.toUpperCase()}]\n${m.content}`)
-      .join('\n\n');
-    const raw = await llm.invoke(prompt);
+    const systemMsg = messages.find((m) => m.role === 'system');
+    const userMsg = messages.find((m) => m.role === 'user');
+    if (!userMsg) {
+      throw new Error('Judge messages payload is missing a user message.');
+    }
+    const raw = await llm.invoke({
+      prompt: userMsg.content,
+      system: systemMsg?.content,
+    });
     return JSON.parse(stripJsonFence(raw));
   };
 }

--- a/src/index.html
+++ b/src/index.html
@@ -34,6 +34,7 @@
             <option value="dynamicExpectedOutcome">
               Dynamic Expected Outcome
             </option>
+            <option value="llmJudge">LLM as Judge</option>
           </select>
         </div>
 

--- a/src/lib/evaluation/constants.ts
+++ b/src/lib/evaluation/constants.ts
@@ -4,6 +4,7 @@ export enum EvaluationApproach {
   ROUGE_1 = 'rouge-1',
   ROUGE_L = 'rouge-L',
   BLEU = 'bleu',
+  LLM_JUDGE = 'llm-judge',
 }
 
 // Array of all evaluation approach values for UI components
@@ -12,6 +13,7 @@ export const EvaluationApproachValues = Object.values(EvaluationApproach);
 export const DEFAULT_ROUGE_PASS_SCORE = 0.7;
 export const DEFAULT_SEMANTIC_PASS_SCORE = 0.7;
 export const DEFAULT_BLEU_PASS_SCORE = 0.7;
+export const DEFAULT_LLM_JUDGE_PASS_SCORE = 0.7;
 
 export function getDefaultPassScoreForApproach(
   approach: EvaluationApproach,
@@ -24,6 +26,8 @@ export function getDefaultPassScoreForApproach(
       return DEFAULT_SEMANTIC_PASS_SCORE;
     case EvaluationApproach.BLEU:
       return DEFAULT_BLEU_PASS_SCORE;
+    case EvaluationApproach.LLM_JUDGE:
+      return DEFAULT_LLM_JUDGE_PASS_SCORE;
     case EvaluationApproach.EXACT:
       return undefined;
   }

--- a/src/lib/evaluation/evaluation-engine.spec.ts
+++ b/src/lib/evaluation/evaluation-engine.spec.ts
@@ -15,10 +15,7 @@ import type {
   EvaluationResult,
   FieldEvaluationInput,
 } from './types';
-import type {
-  JudgeMessage,
-  LlmJudge,
-} from '../../types/llm-test-runner';
+import type { LlmJudge } from '../../types/llm-test-runner';
 
 const mockJudge = jest.fn<LlmJudge>();
 
@@ -93,40 +90,6 @@ describe('LLMEvaluationEngine — llm-judge dispatch', () => {
     // The mock callback was invoked, proving the V2 → field-request → evaluator
     // plumbing wired the reference all the way through.
     expect(mockJudge).toHaveBeenCalledTimes(1);
-  });
-
-  it('plumbs chatHistory from V2 into the prompt sent to the judge', async () => {
-    mockJudge.mockResolvedValue({
-      criteria: [{ id: 'correctness', score: 0.9 }],
-    });
-
-    await runEngine(
-      engine,
-      buildRequest({ chatHistory: 'user: hi\nassistant: hello' }),
-    );
-
-    const args = mockJudge.mock.calls[0][0] as { messages: JudgeMessage[] };
-    expect(args.messages[1].content).toContain(
-      'CHAT_HISTORY:\nuser: hi\nassistant: hello',
-    );
-  });
-
-  it('plumbs additionalContext from V2 into the prompt sent to the judge', async () => {
-    mockJudge.mockResolvedValue({
-      criteria: [{ id: 'correctness', score: 0.9 }],
-    });
-
-    await runEngine(
-      engine,
-      buildRequest({
-        additionalContext: 'Wikipedia snippet about France.',
-      }),
-    );
-
-    const args = mockJudge.mock.calls[0][0] as { messages: JudgeMessage[] };
-    expect(args.messages[1].content).toContain(
-      'ADDITIONAL_CONTEXT:\nWikipedia snippet about France.',
-    );
   });
 
   it('maps EvaluationResult.error onto FieldEvaluationResult.error', async () => {

--- a/src/lib/evaluation/evaluation-engine.spec.ts
+++ b/src/lib/evaluation/evaluation-engine.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// The semantic evaluator transitively imports `@xenova/transformers`, an ESM
+// module Jest cannot parse without extra config. We don't exercise the
+// semantic path in this spec, so stub the module — `jest.mock` is hoisted
+// above the engine import below by babel-jest.
+jest.mock('./evaluators/semantic/index', () => ({
+  performSemanticEvaluation: jest.fn(),
+}));
+
+import { LLMEvaluationEngine } from './evaluation-engine';
+import { EvaluationApproach } from './constants';
+import type {
+  EvaluationRequestV2,
+  EvaluationResult,
+  FieldEvaluationInput,
+} from './types';
+import type {
+  JudgeMessage,
+  LlmJudge,
+} from '../../types/llm-test-runner';
+
+const mockJudge = jest.fn<LlmJudge>();
+
+function buildField(
+  overrides: Partial<FieldEvaluationInput> = {},
+): FieldEvaluationInput {
+  return {
+    index: 0,
+    label: 'Expected Outcome',
+    type: 'textarea',
+    expectedValue: 'Paris',
+    actualResponse: 'The capital is Paris.',
+    evaluationParameters: {
+      approach: EvaluationApproach.LLM_JUDGE,
+      criteria: [
+        { id: 'correctness', description: 'Factually correct.', weight: 1 },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function buildRequest(
+  overrides: Partial<EvaluationRequestV2> = {},
+): EvaluationRequestV2 {
+  return {
+    testCaseId: 'tc-1',
+    question: 'What is the capital of France?',
+    fields: [buildField()],
+    llmJudge: mockJudge,
+    ...overrides,
+  };
+}
+
+async function runEngine(
+  engine: LLMEvaluationEngine,
+  request: EvaluationRequestV2,
+): Promise<EvaluationResult> {
+  return new Promise<EvaluationResult>(resolve => {
+    void engine.evaluateResponse(request, resolve);
+  });
+}
+
+describe('LLMEvaluationEngine — llm-judge dispatch', () => {
+  let engine: LLMEvaluationEngine;
+
+  beforeEach(() => {
+    engine = new LLMEvaluationEngine();
+    mockJudge.mockReset();
+  });
+
+  it('routes the LLM_JUDGE approach to the llm-judge evaluator', async () => {
+    mockJudge.mockResolvedValue({
+      criteria: [{ id: 'correctness', score: 0.9 }],
+    });
+
+    const result = await runEngine(engine, buildRequest());
+
+    expect(
+      result.fieldResults?.[0].evaluationApproachResult.approachUsed,
+    ).toBe(EvaluationApproach.LLM_JUDGE);
+    expect(result.fieldResults?.[0].evaluationApproachResult.score).toBe(0.9);
+  });
+
+  it('plumbs the llmJudge callback through V2 → V1 → evaluator', async () => {
+    mockJudge.mockResolvedValue({
+      criteria: [{ id: 'correctness', score: 0.9 }],
+    });
+
+    await runEngine(engine, buildRequest());
+
+    // The mock callback was invoked, proving the V2 → field-request → evaluator
+    // plumbing wired the reference all the way through.
+    expect(mockJudge).toHaveBeenCalledTimes(1);
+  });
+
+  it('plumbs chatHistory from V2 into the prompt sent to the judge', async () => {
+    mockJudge.mockResolvedValue({
+      criteria: [{ id: 'correctness', score: 0.9 }],
+    });
+
+    await runEngine(
+      engine,
+      buildRequest({ chatHistory: 'user: hi\nassistant: hello' }),
+    );
+
+    const args = mockJudge.mock.calls[0][0] as { messages: JudgeMessage[] };
+    expect(args.messages[1].content).toContain(
+      'CHAT_HISTORY:\nuser: hi\nassistant: hello',
+    );
+  });
+
+  it('plumbs additionalContext from V2 into the prompt sent to the judge', async () => {
+    mockJudge.mockResolvedValue({
+      criteria: [{ id: 'correctness', score: 0.9 }],
+    });
+
+    await runEngine(
+      engine,
+      buildRequest({
+        additionalContext: 'Wikipedia snippet about France.',
+      }),
+    );
+
+    const args = mockJudge.mock.calls[0][0] as { messages: JudgeMessage[] };
+    expect(args.messages[1].content).toContain(
+      'ADDITIONAL_CONTEXT:\nWikipedia snippet about France.',
+    );
+  });
+
+  it('maps EvaluationResult.error onto FieldEvaluationResult.error', async () => {
+    mockJudge.mockRejectedValue(new Error('rate limited'));
+
+    const result = await runEngine(engine, buildRequest());
+
+    expect(result.fieldResults?.[0].error).toContain('rate limited');
+    expect(result.fieldResults?.[0].passed).toBe(false);
+  });
+
+  it('aggregates passed=false when any field has an error, even if another passes', async () => {
+    mockJudge
+      .mockResolvedValueOnce({ criteria: [{ id: 'correctness', score: 0.9 }] })
+      .mockRejectedValueOnce(new Error('boom'));
+
+    const result = await runEngine(
+      engine,
+      buildRequest({
+        fields: [buildField({ index: 0 }), buildField({ index: 1 })],
+      }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.fieldResults?.[0].passed).toBe(true);
+    expect(result.fieldResults?.[0].error).toBeUndefined();
+    expect(result.fieldResults?.[1].passed).toBe(false);
+    expect(result.fieldResults?.[1].error).toContain('boom');
+  });
+});

--- a/src/lib/evaluation/evaluation-engine.ts
+++ b/src/lib/evaluation/evaluation-engine.ts
@@ -42,6 +42,9 @@ export class LLMEvaluationEngine {
           evaluationParameters: result.evaluationParameters!,
           evaluationApproachResult: result.evaluationApproachResult,
           ...(result.error ? { error: result.error } : {}),
+          ...(result.criterionResults
+            ? { criterionResults: result.criterionResults }
+            : {}),
         };
         return fieldResult;
       }),

--- a/src/lib/evaluation/evaluation-engine.ts
+++ b/src/lib/evaluation/evaluation-engine.ts
@@ -27,8 +27,6 @@ export class LLMEvaluationEngine {
           expectedOutcome: field.expectedValue,
           evaluationParameters: field.evaluationParameters,
           llmJudge: request.llmJudge,
-          chatHistory: request.chatHistory,
-          additionalContext: request.additionalContext,
         };
         const result = await this.evaluateField(fieldRequest);
 

--- a/src/lib/evaluation/evaluation-engine.ts
+++ b/src/lib/evaluation/evaluation-engine.ts
@@ -11,6 +11,7 @@ import { performRouge1Evaluation } from './evaluators/rouge1-evaluator';
 import { performSemanticEvaluation } from './evaluators/semantic/index';
 import { performRougeLEvaluation } from './evaluators/rougeL-evaluator';
 import { performBleuEvaluation } from './evaluators/bleu/bleu-evaluator';
+import { performLlmJudgeEvaluation } from './evaluators/llm-judge/llm-judge-evaluator';
 
 export class LLMEvaluationEngine {
   async evaluateResponse(
@@ -25,6 +26,9 @@ export class LLMEvaluationEngine {
           actualResponse: field.actualResponse,
           expectedOutcome: field.expectedValue,
           evaluationParameters: field.evaluationParameters,
+          llmJudge: request.llmJudge,
+          chatHistory: request.chatHistory,
+          additionalContext: request.additionalContext,
         };
         const result = await this.evaluateField(fieldRequest);
 
@@ -37,6 +41,7 @@ export class LLMEvaluationEngine {
           keywordMatches: result.keywordMatches,
           evaluationParameters: result.evaluationParameters!,
           evaluationApproachResult: result.evaluationApproachResult,
+          ...(result.error ? { error: result.error } : {}),
         };
         return fieldResult;
       }),
@@ -91,6 +96,8 @@ export class LLMEvaluationEngine {
         return performRougeLEvaluation(request);
       case EvaluationApproach.SEMANTIC:
         return performSemanticEvaluation(request);
+      case EvaluationApproach.LLM_JUDGE:
+        return performLlmJudgeEvaluation(request);
       default:
         console.warn(
           `Unknown matching approach: ${request.evaluationParameters.approach}, falling back to exact matching`,

--- a/src/lib/evaluation/evaluation-service.spec.ts
+++ b/src/lib/evaluation/evaluation-service.spec.ts
@@ -11,11 +11,7 @@ jest.mock('./evaluators/semantic/index', () => ({
 import { EvaluationService } from './evaluation-service';
 import { EvaluationApproach } from './constants';
 import type { EvaluationResult } from './types';
-import type {
-  JudgeMessage,
-  LlmJudge,
-  TestCase,
-} from '../../types/llm-test-runner';
+import type { LlmJudge, TestCase } from '../../types/llm-test-runner';
 
 const mockJudge = jest.fn<LlmJudge>();
 
@@ -70,46 +66,5 @@ describe('EvaluationService — llm-judge plumbing', () => {
   it('passes the llmJudge callback through to the engine and the evaluator', async () => {
     await runService(service, buildTestCase(), mockJudge);
     expect(mockJudge).toHaveBeenCalledTimes(1);
-  });
-
-  it('derives chatHistory from the test case when enabled and non-empty', async () => {
-    await runService(
-      service,
-      buildTestCase({
-        chatHistory: { enabled: true, value: 'user: hi\nassistant: hello' },
-      }),
-      mockJudge,
-    );
-
-    const args = mockJudge.mock.calls[0][0] as { messages: JudgeMessage[] };
-    expect(args.messages[1].content).toContain(
-      'CHAT_HISTORY:\nuser: hi\nassistant: hello',
-    );
-  });
-
-  it('omits chatHistory when disabled, even if a value is set', async () => {
-    await runService(
-      service,
-      buildTestCase({
-        chatHistory: { enabled: false, value: 'user: hi' },
-      }),
-      mockJudge,
-    );
-
-    const args = mockJudge.mock.calls[0][0] as { messages: JudgeMessage[] };
-    expect(args.messages[1].content).not.toContain('CHAT_HISTORY:');
-  });
-
-  it('omits chatHistory when enabled but value is empty', async () => {
-    await runService(
-      service,
-      buildTestCase({
-        chatHistory: { enabled: true, value: '' },
-      }),
-      mockJudge,
-    );
-
-    const args = mockJudge.mock.calls[0][0] as { messages: JudgeMessage[] };
-    expect(args.messages[1].content).not.toContain('CHAT_HISTORY:');
   });
 });

--- a/src/lib/evaluation/evaluation-service.spec.ts
+++ b/src/lib/evaluation/evaluation-service.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// The semantic evaluator transitively imports `@xenova/transformers`, an ESM
+// module Jest cannot parse without extra config. We don't exercise the
+// semantic path in this spec, so stub the module — `jest.mock` is hoisted
+// above the service import below by babel-jest.
+jest.mock('./evaluators/semantic/index', () => ({
+  performSemanticEvaluation: jest.fn(),
+}));
+
+import { EvaluationService } from './evaluation-service';
+import { EvaluationApproach } from './constants';
+import type { EvaluationResult } from './types';
+import type {
+  JudgeMessage,
+  LlmJudge,
+  TestCase,
+} from '../../types/llm-test-runner';
+
+const mockJudge = jest.fn<LlmJudge>();
+
+function buildTestCase(overrides: Partial<TestCase> = {}): TestCase {
+  return {
+    id: 'tc-1',
+    question: 'What is the capital of France?',
+    expectedOutcome: [
+      {
+        type: 'textarea',
+        label: 'Expected Outcome',
+        value: 'Paris',
+        outcomeMode: 'static',
+        evaluationParameters: {
+          approach: EvaluationApproach.LLM_JUDGE,
+          criteria: [
+            { id: 'correctness', description: 'Factually correct.', weight: 1 },
+          ],
+        },
+      },
+    ],
+    output: {
+      text: 'The capital is Paris.',
+    },
+    chatHistory: { enabled: false, value: '' },
+    isRunning: false,
+    ...overrides,
+  };
+}
+
+async function runService(
+  service: EvaluationService,
+  testCase: TestCase,
+  llmJudge?: LlmJudge,
+): Promise<EvaluationResult> {
+  return new Promise<EvaluationResult>(resolve => {
+    void service.evaluateTestCase(testCase, resolve, undefined, llmJudge);
+  });
+}
+
+describe('EvaluationService — llm-judge plumbing', () => {
+  let service: EvaluationService;
+
+  beforeEach(() => {
+    service = new EvaluationService();
+    mockJudge.mockReset();
+    mockJudge.mockResolvedValue({
+      criteria: [{ id: 'correctness', score: 0.9 }],
+    });
+  });
+
+  it('passes the llmJudge callback through to the engine and the evaluator', async () => {
+    await runService(service, buildTestCase(), mockJudge);
+    expect(mockJudge).toHaveBeenCalledTimes(1);
+  });
+
+  it('derives chatHistory from the test case when enabled and non-empty', async () => {
+    await runService(
+      service,
+      buildTestCase({
+        chatHistory: { enabled: true, value: 'user: hi\nassistant: hello' },
+      }),
+      mockJudge,
+    );
+
+    const args = mockJudge.mock.calls[0][0] as { messages: JudgeMessage[] };
+    expect(args.messages[1].content).toContain(
+      'CHAT_HISTORY:\nuser: hi\nassistant: hello',
+    );
+  });
+
+  it('omits chatHistory when disabled, even if a value is set', async () => {
+    await runService(
+      service,
+      buildTestCase({
+        chatHistory: { enabled: false, value: 'user: hi' },
+      }),
+      mockJudge,
+    );
+
+    const args = mockJudge.mock.calls[0][0] as { messages: JudgeMessage[] };
+    expect(args.messages[1].content).not.toContain('CHAT_HISTORY:');
+  });
+
+  it('omits chatHistory when enabled but value is empty', async () => {
+    await runService(
+      service,
+      buildTestCase({
+        chatHistory: { enabled: true, value: '' },
+      }),
+      mockJudge,
+    );
+
+    const args = mockJudge.mock.calls[0][0] as { messages: JudgeMessage[] };
+    expect(args.messages[1].content).not.toContain('CHAT_HISTORY:');
+  });
+});

--- a/src/lib/evaluation/evaluation-service.ts
+++ b/src/lib/evaluation/evaluation-service.ts
@@ -9,6 +9,7 @@ import {
   TestCase,
   ExpectedOutcomeField,
   EvaluationSourceExtractors,
+  LlmJudge,
 } from '../../types/llm-test-runner';
 import { normalizeEvaluationParametersForField } from './field-evaluation-approach';
 import { resolveActualValue } from './actual-value-resolver';
@@ -33,6 +34,7 @@ export class EvaluationService {
     testCase: TestCase,
     onResult: (result: EvaluationResult) => void,
     extractors?: EvaluationSourceExtractors,
+    llmJudge?: LlmJudge,
   ): Promise<void> {
     const fields: FieldEvaluationInput[] = [];
     const failedFields: FieldEvaluationResult[] = [];
@@ -111,10 +113,20 @@ export class EvaluationService {
       return;
     }
 
+    // Derive chatHistory from the test case so the llm-judge evaluator can
+    // pass it into the judge prompt. Treat disabled / empty values as
+    // undefined so the prompt's CHAT_HISTORY block is omitted entirely.
+    const chatHistory =
+      testCase.chatHistory?.enabled && testCase.chatHistory.value
+        ? testCase.chatHistory.value
+        : undefined;
+
     const evaluationRequest: EvaluationRequestV2 = {
       testCaseId: testCase.id,
       question: testCase.question,
       fields,
+      llmJudge,
+      chatHistory,
     };
 
     await this.engine.evaluateResponse(evaluationRequest, (result: EvaluationResult) => {

--- a/src/lib/evaluation/evaluation-service.ts
+++ b/src/lib/evaluation/evaluation-service.ts
@@ -113,20 +113,11 @@ export class EvaluationService {
       return;
     }
 
-    // Derive chatHistory from the test case so the llm-judge evaluator can
-    // pass it into the judge prompt. Treat disabled / empty values as
-    // undefined so the prompt's CHAT_HISTORY block is omitted entirely.
-    const chatHistory =
-      testCase.chatHistory?.enabled && testCase.chatHistory.value
-        ? testCase.chatHistory.value
-        : undefined;
-
     const evaluationRequest: EvaluationRequestV2 = {
       testCaseId: testCase.id,
       question: testCase.question,
       fields,
       llmJudge,
-      chatHistory,
     };
 
     await this.engine.evaluateResponse(evaluationRequest, (result: EvaluationResult) => {

--- a/src/lib/evaluation/evaluators/llm-judge/llm-judge-evaluator.ts
+++ b/src/lib/evaluation/evaluators/llm-judge/llm-judge-evaluator.ts
@@ -1,0 +1,176 @@
+import { z } from 'zod';
+import type { Criterion } from '../../../../schemas/expected-outcome';
+import {
+  EvaluationApproach,
+  DEFAULT_LLM_JUDGE_PASS_SCORE,
+} from '../../constants';
+import type {
+  CriterionResult,
+  EvaluationRequest,
+  EvaluationResult,
+} from '../../types';
+import { buildJudgeMessages } from './prompt-template';
+
+const DEFAULT_CORRECTNESS_CRITERION: Criterion = {
+  id: 'correctness',
+  description:
+    'Determine whether the actual output is factually correct based on the expected output.',
+  weight: 1,
+};
+
+const judgeResponseSchema = z.object({
+  criteria: z
+    .array(
+      z.object({
+        id: z.string().min(1),
+        score: z.number().min(0).max(1),
+        reason: z.string().optional(),
+      }),
+    )
+    .min(1),
+});
+
+function validateCoverage(
+  inputCriteria: Criterion[],
+  judgeCriteriaIds: Set<string>,
+) {
+  const missing = inputCriteria
+    .map(c => c.id)
+    .filter(id => !judgeCriteriaIds.has(id));
+
+  if (missing.length > 0) {
+    return `Judge response is missing scores for criteria: ${missing.join(', ')}`;
+  }
+  return null;
+}
+
+const resolveCriteria = (criteria: Criterion[] | undefined): Criterion[] => {
+  if (!criteria || criteria.length === 0) {
+    return [DEFAULT_CORRECTNESS_CRITERION];
+  }
+  return criteria;
+};
+
+const weightOf = (criterion: Criterion): number => {
+  return criterion.weight ?? 1;
+};
+
+const computeWeightedAverage = (
+  criterionResults: CriterionResult[],
+): number => {
+  const totalWeightedScore = criterionResults.reduce((sum, result) => {
+    return sum + result.score * result.weight;
+  }, 0);
+  const totalWeight = criterionResults.reduce((sum, result) => {
+    return sum + result.weight;
+  }, 0);
+  return totalWeight > 0 ? totalWeightedScore / totalWeight : 0;
+};
+
+/**
+ * Builds an `EvaluationResult` representing a failed llm-judge evaluation.
+ * Used for every recoverable failure path (missing callback, judge throws,
+ * schema mismatch, coverage failure) so the caller can surface a consistent
+ * error in the evaluation-row UI via {@link EvaluationResult.error}.
+ */
+function buildErrorResult(
+  request: EvaluationRequest,
+  errorMessage: string,
+): EvaluationResult {
+  const threshold =
+    request.evaluationParameters.threshold ?? DEFAULT_LLM_JUDGE_PASS_SCORE;
+  return {
+    testCaseId: request.testCaseId,
+    passed: false,
+    keywordMatches: [],
+    timestamp: new Date().toISOString(),
+    evaluationParameters: { ...request.evaluationParameters, threshold },
+    evaluationApproachResult: {
+      score: 0,
+      approachUsed: EvaluationApproach.LLM_JUDGE,
+    },
+    error: errorMessage,
+  };
+}
+
+export async function performLlmJudgeEvaluation(
+  request: EvaluationRequest,
+): Promise<EvaluationResult> {
+  if (!request.llmJudge) {
+    return buildErrorResult(
+      request,
+      'llmJudge callback is required for llm-judge evaluation.',
+    );
+  }
+  const criteria = resolveCriteria(request.evaluationParameters.criteria);
+  const {
+    testCaseId,
+    question,
+    expectedOutcome,
+    actualResponse: assistantResponse,
+    evaluationParameters,
+    llmJudge,
+    chatHistory,
+    additionalContext,
+  } = request;
+  const messages = buildJudgeMessages({
+    question,
+    expectedOutcome,
+    assistantResponse,
+    chatHistory,
+    additionalContext,
+    criteria,
+  });
+
+  let judgeResponse;
+  try {
+    judgeResponse = await llmJudge({ messages });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return buildErrorResult(request, `Judge call failed: ${message}`);
+  }
+
+  const parsed = judgeResponseSchema.safeParse(judgeResponse);
+  if (!parsed.success) {
+    return buildErrorResult(
+      request,
+      `Judge response schema validation failed: ${parsed.error.message}`,
+    );
+  }
+
+  const judgeIds = new Set(parsed.data.criteria.map(c => c.id));
+  const coverageError = validateCoverage(criteria, judgeIds);
+  if (coverageError) {
+    return buildErrorResult(request, coverageError);
+  }
+
+  const criterionResults: CriterionResult[] = criteria.map(criterion => {
+    const judgeResult = parsed.data.criteria.find(
+      jc => jc.id === criterion.id,
+    )!;
+    return {
+      id: criterion.id,
+      description: criterion.description,
+      weight: weightOf(criterion),
+      score: judgeResult.score,
+      reason: judgeResult.reason,
+    };
+  });
+
+  const finalScore = computeWeightedAverage(criterionResults);
+  const threshold =
+    evaluationParameters.threshold ?? DEFAULT_LLM_JUDGE_PASS_SCORE;
+
+  return {
+    testCaseId,
+    passed: finalScore >= threshold,
+    keywordMatches: [],
+    criterionResults,
+    timestamp: new Date().toISOString(),
+    evaluationParameters: { ...evaluationParameters, threshold },
+    evaluationApproachResult: {
+      score: finalScore,
+      approachUsed: EvaluationApproach.LLM_JUDGE,
+    },
+  };
+}

--- a/src/lib/evaluation/evaluators/llm-judge/llm-judge-evaluator.ts
+++ b/src/lib/evaluation/evaluators/llm-judge/llm-judge-evaluator.ts
@@ -30,6 +30,29 @@ const judgeResponseSchema = z.object({
     .min(1),
 });
 
+/**
+ * Translates Zod validation errors into a human-readable bullet list so
+ * the user sees actionable feedback in the UI rather than the raw issue
+ * tree. Caps at five issues to keep the error pill compact; the full
+ * detail is still in `parsed.error.issues` if a consumer needs it.
+ *
+ * Example output:
+ *   Judge response invalid:
+ *     • criteria.0.score: must be ≤ 1 (got 1.5)
+ *     • criteria.1.id: required
+ */
+function formatJudgeValidationError(error: z.ZodError): string {
+  const issues = error.issues.slice(0, 5).map(issue => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+    return `  • ${path}: ${issue.message}`;
+  });
+  const remaining = error.issues.length - issues.length;
+  if (remaining > 0) {
+    issues.push(`  • (+${remaining} more issue${remaining === 1 ? '' : 's'})`);
+  }
+  return `Judge response invalid:\n${issues.join('\n')}`;
+}
+
 function validateCoverage(
   inputCriteria: Criterion[],
   judgeCriteriaIds: Set<string>,
@@ -110,15 +133,11 @@ export async function performLlmJudgeEvaluation(
     actualResponse: assistantResponse,
     evaluationParameters,
     llmJudge,
-    chatHistory,
-    additionalContext,
   } = request;
   const messages = buildJudgeMessages({
     question,
     expectedOutcome,
     assistantResponse,
-    chatHistory,
-    additionalContext,
     criteria,
   });
 
@@ -132,10 +151,7 @@ export async function performLlmJudgeEvaluation(
 
   const parsed = judgeResponseSchema.safeParse(judgeResponse);
   if (!parsed.success) {
-    return buildErrorResult(
-      request,
-      `Judge response schema validation failed: ${parsed.error.message}`,
-    );
+    return buildErrorResult(request, formatJudgeValidationError(parsed.error));
   }
 
   const judgeIds = new Set(parsed.data.criteria.map(c => c.id));

--- a/src/lib/evaluation/evaluators/llm-judge/prompt-template.spec.ts
+++ b/src/lib/evaluation/evaluators/llm-judge/prompt-template.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  buildJudgeMessages,
+  type JudgePromptInput,
+} from './prompt-template';
+import type { Criterion } from '../../../../schemas/expected-outcome';
+
+const baseCriteria: Criterion[] = [
+  { id: 'correctness', description: 'Factually correct.', weight: 2 },
+  { id: 'concision', description: 'Concise and on point.' },
+];
+
+const baseInput: JudgePromptInput = {
+  question: 'What is the capital of France?',
+  expectedOutcome: 'Paris',
+  assistantResponse: 'The capital is Paris.',
+  criteria: baseCriteria,
+};
+
+describe('buildJudgeMessages', () => {
+  it('returns [system, user] messages with the correct roles in order', () => {
+    const messages = buildJudgeMessages(baseInput);
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe('system');
+    expect(messages[1].role).toBe('user');
+  });
+
+  it('renders a non-empty system message containing the impartial-evaluator instructions', () => {
+    const messages = buildJudgeMessages(baseInput);
+    expect(messages[0].content).toContain('You are an impartial evaluator');
+    expect(messages[0].content).toContain('Required JSON shape');
+  });
+
+  it('renders the default user message with every input value in its slot', () => {
+    const userContent = buildJudgeMessages(baseInput)[1].content;
+    expect(userContent).toContain('USER_PROMPT:\nWhat is the capital of France?');
+    expect(userContent).toContain('EXPECTED_OUTCOME:\nParis');
+    expect(userContent).toContain('ASSISTANT_RESPONSE:\nThe capital is Paris.');
+  });
+
+  it('renders criteria as pretty-printed JSON that round-trips and includes weights', () => {
+    const userContent = buildJudgeMessages(baseInput)[1].content;
+    const expectedJson = JSON.stringify(baseCriteria, null, 2);
+    expect(userContent).toContain(`CRITERIA:\n${expectedJson}`);
+    expect(userContent).toContain('"weight": 2');
+  });
+
+  it('omits the chat history label when chatHistory is undefined', () => {
+    const userContent = buildJudgeMessages(baseInput)[1].content;
+    expect(userContent).not.toContain('CHAT_HISTORY:');
+  });
+
+  it('renders a labeled chat history block when chatHistory is provided', () => {
+    const userContent = buildJudgeMessages({
+      ...baseInput,
+      chatHistory: 'user: hi\nassistant: hello',
+    })[1].content;
+    expect(userContent).toContain(
+      'CHAT_HISTORY:\nuser: hi\nassistant: hello',
+    );
+  });
+
+  it('omits the additional context label when additionalContext is undefined', () => {
+    const userContent = buildJudgeMessages(baseInput)[1].content;
+    expect(userContent).not.toContain('ADDITIONAL_CONTEXT:');
+  });
+
+  it('renders a labeled additional context block when additionalContext is provided', () => {
+    const userContent = buildJudgeMessages({
+      ...baseInput,
+      additionalContext: 'Page snippet: Paris is the capital of France.',
+    })[1].content;
+    expect(userContent).toContain(
+      'ADDITIONAL_CONTEXT:\nPage snippet: Paris is the capital of France.',
+    );
+  });
+
+  it('honors a userTemplate override; system stays default', () => {
+    // Capture the default system content from a no-override call so we can
+    // assert stability without needing the system constant exported.
+    const defaultSystem = buildJudgeMessages(baseInput)[0].content;
+
+    const customUser = 'Q: ${question}\nA: ${assistant_response}';
+    const messages = buildJudgeMessages({
+      ...baseInput,
+      userTemplate: customUser,
+    });
+
+    expect(messages[0].content).toBe(defaultSystem);
+    expect(messages[1].content).toBe(
+      'Q: What is the capital of France?\nA: The capital is Paris.',
+    );
+  });
+
+  it('throws when criteria is empty', () => {
+    expect(() =>
+      buildJudgeMessages({ ...baseInput, criteria: [] }),
+    ).toThrow();
+  });
+
+  it('user-template path does not re-interpolate placeholder-like text inside replacement values', () => {
+    const messages = buildJudgeMessages({
+      ...baseInput,
+      assistantResponse: 'I would say ${question} is the question.',
+      userTemplate: 'Q: ${question}\nA: ${assistant_response}',
+    });
+    // Single-pass regex substitution must NOT re-scan replacement values:
+    // the literal `${question}` inside the assistant response stays intact.
+    expect(messages[1].content).toBe(
+      'Q: What is the capital of France?\nA: I would say ${question} is the question.',
+    );
+  });
+
+  it('default path embeds placeholder-like text from inputs as literal', () => {
+    // JS template literals are not recursive, so `${question}` embedded in an
+    // input value can never become a re-interpolated placeholder.
+    const userContent = buildJudgeMessages({
+      ...baseInput,
+      assistantResponse: 'I would say ${question} is the question.',
+    })[1].content;
+    expect(userContent).toContain(
+      'ASSISTANT_RESPONSE:\nI would say ${question} is the question.',
+    );
+    expect(userContent).toContain('USER_PROMPT:\nWhat is the capital of France?');
+  });
+});

--- a/src/lib/evaluation/evaluators/llm-judge/prompt-template.spec.ts
+++ b/src/lib/evaluation/evaluators/llm-judge/prompt-template.spec.ts
@@ -45,75 +45,16 @@ describe('buildJudgeMessages', () => {
     expect(userContent).toContain('"weight": 2');
   });
 
-  it('omits the chat history label when chatHistory is undefined', () => {
-    const userContent = buildJudgeMessages(baseInput)[1].content;
-    expect(userContent).not.toContain('CHAT_HISTORY:');
-  });
-
-  it('renders a labeled chat history block when chatHistory is provided', () => {
-    const userContent = buildJudgeMessages({
-      ...baseInput,
-      chatHistory: 'user: hi\nassistant: hello',
-    })[1].content;
-    expect(userContent).toContain(
-      'CHAT_HISTORY:\nuser: hi\nassistant: hello',
-    );
-  });
-
-  it('omits the additional context label when additionalContext is undefined', () => {
-    const userContent = buildJudgeMessages(baseInput)[1].content;
-    expect(userContent).not.toContain('ADDITIONAL_CONTEXT:');
-  });
-
-  it('renders a labeled additional context block when additionalContext is provided', () => {
-    const userContent = buildJudgeMessages({
-      ...baseInput,
-      additionalContext: 'Page snippet: Paris is the capital of France.',
-    })[1].content;
-    expect(userContent).toContain(
-      'ADDITIONAL_CONTEXT:\nPage snippet: Paris is the capital of France.',
-    );
-  });
-
-  it('honors a userTemplate override; system stays default', () => {
-    // Capture the default system content from a no-override call so we can
-    // assert stability without needing the system constant exported.
-    const defaultSystem = buildJudgeMessages(baseInput)[0].content;
-
-    const customUser = 'Q: ${question}\nA: ${assistant_response}';
-    const messages = buildJudgeMessages({
-      ...baseInput,
-      userTemplate: customUser,
-    });
-
-    expect(messages[0].content).toBe(defaultSystem);
-    expect(messages[1].content).toBe(
-      'Q: What is the capital of France?\nA: The capital is Paris.',
-    );
-  });
-
   it('throws when criteria is empty', () => {
     expect(() =>
       buildJudgeMessages({ ...baseInput, criteria: [] }),
     ).toThrow();
   });
 
-  it('user-template path does not re-interpolate placeholder-like text inside replacement values', () => {
-    const messages = buildJudgeMessages({
-      ...baseInput,
-      assistantResponse: 'I would say ${question} is the question.',
-      userTemplate: 'Q: ${question}\nA: ${assistant_response}',
-    });
+  it('does not re-interpolate placeholder-like text inside input values', () => {
     // Single-pass regex substitution must NOT re-scan replacement values:
-    // the literal `${question}` inside the assistant response stays intact.
-    expect(messages[1].content).toBe(
-      'Q: What is the capital of France?\nA: I would say ${question} is the question.',
-    );
-  });
-
-  it('default path embeds placeholder-like text from inputs as literal', () => {
-    // JS template literals are not recursive, so `${question}` embedded in an
-    // input value can never become a re-interpolated placeholder.
+    // a literal `${question}` inside the assistant response stays intact
+    // and does not get expanded again.
     const userContent = buildJudgeMessages({
       ...baseInput,
       assistantResponse: 'I would say ${question} is the question.',

--- a/src/lib/evaluation/evaluators/llm-judge/prompt-template.ts
+++ b/src/lib/evaluation/evaluators/llm-judge/prompt-template.ts
@@ -1,0 +1,169 @@
+import type { Criterion } from '../../../../schemas/expected-outcome';
+import type { JudgeMessage } from '../../../../types/llm-test-runner';
+
+/**
+ * Input to {@link buildJudgeMessages}.
+ *
+ * `chatHistory` and `additionalContext` are optional. When omitted, their
+ * corresponding sections are dropped from the prompt entirely — no empty
+ * `CHAT_HISTORY:` / `ADDITIONAL_CONTEXT:` header is rendered.
+ *
+ * `userTemplate`, when provided, replaces the library default user message
+ * template. It must use `${key}` placeholders for any of the supported keys:
+ * `question`, `expected_outcome`, `assistant_response`, `chat_history_block`,
+ * `additional_context_block`, `criteria_json`. Unknown placeholders are left
+ * as literal text in the rendered prompt.
+ */
+export interface JudgePromptInput {
+  question: string;
+  expectedOutcome: string;
+  assistantResponse: string;
+  criteria: Criterion[];
+  chatHistory?: string;
+  additionalContext?: string;
+  userTemplate?: string;
+}
+
+function formatBlock(label: string, value: string | undefined): string {
+  if (!value || value.trim() === '') {
+    return '';
+  }
+  return `${label}:\n${value}`;
+}
+
+const PLACEHOLDER_KEYS = [
+  'question',
+  'expected_outcome',
+  'assistant_response',
+  'chat_history_block',
+  'additional_context_block',
+  'criteria_json',
+] as const;
+
+type PlaceholderKey = (typeof PLACEHOLDER_KEYS)[number];
+type PlaceholderVars = Record<PlaceholderKey, string>;
+
+const PLACEHOLDER_PATTERN = new RegExp(
+  '\\$\\{(' + PLACEHOLDER_KEYS.join('|') + ')\\}',
+  'g',
+);
+
+const DEFAULT_JUDGE_SYSTEM_TEMPLATE = `
+You are an impartial evaluator.
+
+Evaluate the assistant response against the user prompt and expected outcome using ONLY the provided criteria.
+
+Scoring rules:
+- For each criterion, assign a numeric score in the range [0, 1].
+- 1.0 = fully satisfies the criterion.
+- 0.0 = does not satisfy the criterion.
+- Use intermediate values for partial satisfaction.
+- Judge substance over style.
+- Do NOT reward verbosity unless a criterion explicitly asks for detail/depth.
+- Do NOT penalize concise but correct responses.
+
+Reasoning rules:
+- For each criterion, provide a brief reason tied to specific details from:
+  - user prompt
+  - expected outcome
+  - assistant response
+  - additional context (if provided)
+- Keep reasons concise and evaluation-focused.
+- Do not invent criteria beyond what is provided.
+
+Output rules (strict):
+- Return ONLY valid JSON.
+- No markdown, no code fences, no extra commentary.
+- Include every criterion id exactly once.
+- All scores must be numeric and within [0, 1].
+
+Required JSON shape:
+{
+  "criteria": [
+    {
+      "id": "criterion_id",
+      "score": 0.0,
+      "reason": "brief criterion-specific justification"
+    }
+  ]
+}`;
+
+function interpolate(template: string, vars: PlaceholderVars): string {
+  return template.replace(
+    PLACEHOLDER_PATTERN,
+    (_, key: PlaceholderKey) => vars[key],
+  );
+}
+
+function buildDefaultJudgeUserMessage(
+  input: Omit<JudgePromptInput, 'userTemplate'>,
+): string {
+  return `
+Evaluation Steps:
+1) Read USER_PROMPT and EXPECTED_OUTCOME to determine target behavior.
+2) Read ASSISTANT_RESPONSE (and CHAT_HISTORY / ADDITIONAL_CONTEXT if present).
+3) Score each criterion independently in [0,1].
+4) Write concise, evidence-based reasons per criterion.
+5) Return strict JSON only.
+
+USER_PROMPT:
+${input.question}
+
+EXPECTED_OUTCOME:
+${input.expectedOutcome}
+
+ASSISTANT_RESPONSE:
+${input.assistantResponse}
+
+${formatBlock('CHAT_HISTORY', input.chatHistory)}
+
+${formatBlock('ADDITIONAL_CONTEXT', input.additionalContext)}
+
+CRITERIA:
+${JSON.stringify(input.criteria, null, 2)}
+
+JSON:`;
+}
+
+/**
+ * Builds the [system, user] message pair to send to the judge LLM.
+ *
+ * The system message is library-controlled and not overridable in v1.
+ *
+ * The user message is built from `input.userTemplate` (if provided) — a
+ * string with `${key}` placeholders — or from the library default. See
+ * {@link JudgePromptInput} for the supported placeholder keys.
+ *
+ * @throws when `input.criteria` is empty. Callers should substitute in a
+ * default correctness criterion before reaching this point.
+ */
+export function buildJudgeMessages(input: JudgePromptInput): JudgeMessage[] {
+  if (!input.criteria || input.criteria.length === 0) {
+    throw new Error(
+      'buildJudgeMessages: criteria must contain at least one criterion.',
+    );
+  }
+
+  let userContent: string;
+  if (input.userTemplate) {
+    const vars: PlaceholderVars = {
+      question: input.question,
+      expected_outcome: input.expectedOutcome,
+      assistant_response: input.assistantResponse,
+      chat_history_block: formatBlock('CHAT_HISTORY', input.chatHistory),
+      additional_context_block: formatBlock(
+        'ADDITIONAL_CONTEXT',
+        input.additionalContext,
+      ),
+      criteria_json: JSON.stringify(input.criteria, null, 2),
+    };
+    userContent = interpolate(input.userTemplate, vars);
+  } else {
+    userContent = buildDefaultJudgeUserMessage(input);
+  }
+
+  return [
+    { role: 'system', content: DEFAULT_JUDGE_SYSTEM_TEMPLATE },
+    { role: 'user', content: userContent },
+  ];
+}

--- a/src/lib/evaluation/evaluators/llm-judge/prompt-template.ts
+++ b/src/lib/evaluation/evaluators/llm-judge/prompt-template.ts
@@ -4,54 +4,42 @@ import type { JudgeMessage } from '../../../../types/llm-test-runner';
 /**
  * Input to {@link buildJudgeMessages}.
  *
- * `chatHistory` and `additionalContext` are optional. When omitted, their
- * corresponding sections are dropped from the prompt entirely — no empty
- * `CHAT_HISTORY:` / `ADDITIONAL_CONTEXT:` header is rendered.
+ * Both prompts (system and user) are library-controlled in v1. The
+ * system prompt carries the strict-JSON output contract; the user prompt
+ * slots in the four core evaluation inputs. Consumers customize what
+ * gets evaluated via the test case (question, expected outcome,
+ * criteria) and which model judges via the `llmJudge` callback — they
+ * don't override the prompt structure itself.
  *
- * `userTemplate`, when provided, replaces the library default user message
- * template. It must use `${key}` placeholders for any of the supported keys:
- * `question`, `expected_outcome`, `assistant_response`, `chat_history_block`,
- * `additional_context_block`, `criteria_json`. Unknown placeholders are left
- * as literal text in the rendered prompt.
+ * The judge does not receive chat history or "additional context" by
+ * design — those are inputs to the model under test, not to the judge.
+ * The judge scores the assistant's response against the expected outcome
+ * using only the configured criteria.
  */
 export interface JudgePromptInput {
   question: string;
   expectedOutcome: string;
   assistantResponse: string;
   criteria: Criterion[];
-  chatHistory?: string;
-  additionalContext?: string;
-  userTemplate?: string;
 }
 
-function formatBlock(label: string, value: string | undefined): string {
-  if (!value || value.trim() === '') {
-    return '';
-  }
-  return `${label}:\n${value}`;
-}
-
-const PLACEHOLDER_KEYS = [
-  'question',
-  'expected_outcome',
-  'assistant_response',
-  'chat_history_block',
-  'additional_context_block',
-  'criteria_json',
-] as const;
-
-type PlaceholderKey = (typeof PLACEHOLDER_KEYS)[number];
-type PlaceholderVars = Record<PlaceholderKey, string>;
-
-const PLACEHOLDER_PATTERN = new RegExp(
-  '\\$\\{(' + PLACEHOLDER_KEYS.join('|') + ')\\}',
-  'g',
-);
-
-const DEFAULT_JUDGE_SYSTEM_TEMPLATE = `
+/**
+ * Default system prompt — sets the judge's role and the strict JSON output
+ * contract. Consumers who override this MUST keep the JSON shape directive
+ * intact, otherwise the library's response validator will reject the
+ * judge's output and the test will surface as an evaluation error.
+ */
+export const DEFAULT_JUDGE_SYSTEM_TEMPLATE = `
 You are an impartial evaluator.
 
 Evaluate the assistant response against the user prompt and expected outcome using ONLY the provided criteria.
+
+Evaluation Steps:
+1) Read USER_PROMPT and EXPECTED_OUTCOME to determine target behavior.
+2) Read ASSISTANT_RESPONSE (and CHAT_HISTORY / ADDITIONAL_CONTEXT if present).
+3) Score each criterion independently in [0,1].
+4) Write concise, evidence-based reasons per criterion.
+5) Return strict JSON only.
 
 Scoring rules:
 - For each criterion, assign a numeric score in the range [0, 1].
@@ -88,6 +76,57 @@ Required JSON shape:
   ]
 }`;
 
+/**
+ * Default user prompt — slots evaluation data into a fixed structure.
+ * Uses `${key}` placeholders. Consumers can supply their own user template
+ * (e.g. uploaded as a `.txt` file) and the library will interpolate the
+ * same set of placeholder keys into it.
+ *
+ * The default does NOT include `${chat_history_block}` or
+ * `${additional_context_block}` — those placeholders are still supported
+ * for consumers who want to surface them in a custom template, but the
+ * library's default keeps the user prompt focused on the four core
+ * evaluation inputs.
+ */
+export const DEFAULT_JUDGE_USER_TEMPLATE = `
+USER_PROMPT:
+\${question}
+
+EXPECTED_OUTCOME:
+\${expected_outcome}
+
+ASSISTANT_RESPONSE:
+\${assistant_response}
+
+CRITERIA:
+\${criteria_json}
+
+JSON:`;
+
+// ===== Internal helpers =====
+
+const PLACEHOLDER_KEYS = [
+  'question',
+  'expected_outcome',
+  'assistant_response',
+  'criteria_json',
+] as const;
+
+type PlaceholderKey = (typeof PLACEHOLDER_KEYS)[number];
+type PlaceholderVars = Record<PlaceholderKey, string>;
+
+const PLACEHOLDER_PATTERN = new RegExp(
+  '\\$\\{(' + PLACEHOLDER_KEYS.join('|') + ')\\}',
+  'g',
+);
+
+/**
+ * Single-pass placeholder substitution. Each known `${key}` in the
+ * template is replaced by `vars[key]`. Replacement values are NOT
+ * re-scanned, so user content that happens to contain `${question}`
+ * (or any other placeholder) stays as a literal string in the final
+ * prompt.
+ */
 function interpolate(template: string, vars: PlaceholderVars): string {
   return template.replace(
     PLACEHOLDER_PATTERN,
@@ -95,44 +134,13 @@ function interpolate(template: string, vars: PlaceholderVars): string {
   );
 }
 
-function buildDefaultJudgeUserMessage(
-  input: Omit<JudgePromptInput, 'userTemplate'>,
-): string {
-  return `
-Evaluation Steps:
-1) Read USER_PROMPT and EXPECTED_OUTCOME to determine target behavior.
-2) Read ASSISTANT_RESPONSE (and CHAT_HISTORY / ADDITIONAL_CONTEXT if present).
-3) Score each criterion independently in [0,1].
-4) Write concise, evidence-based reasons per criterion.
-5) Return strict JSON only.
-
-USER_PROMPT:
-${input.question}
-
-EXPECTED_OUTCOME:
-${input.expectedOutcome}
-
-ASSISTANT_RESPONSE:
-${input.assistantResponse}
-
-${formatBlock('CHAT_HISTORY', input.chatHistory)}
-
-${formatBlock('ADDITIONAL_CONTEXT', input.additionalContext)}
-
-CRITERIA:
-${JSON.stringify(input.criteria, null, 2)}
-
-JSON:`;
-}
-
 /**
  * Builds the [system, user] message pair to send to the judge LLM.
  *
- * The system message is library-controlled and not overridable in v1.
- *
- * The user message is built from `input.userTemplate` (if provided) — a
- * string with `${key}` placeholders — or from the library default. See
- * {@link JudgePromptInput} for the supported placeholder keys.
+ * Both prompts are built from library-controlled defaults. The system
+ * prompt carries the strict-JSON output contract; the user prompt slots
+ * the four evaluation inputs (question, expected outcome, assistant
+ * response, criteria) into a fixed structure.
  *
  * @throws when `input.criteria` is empty. Callers should substitute in a
  * default correctness criterion before reaching this point.
@@ -144,26 +152,15 @@ export function buildJudgeMessages(input: JudgePromptInput): JudgeMessage[] {
     );
   }
 
-  let userContent: string;
-  if (input.userTemplate) {
-    const vars: PlaceholderVars = {
-      question: input.question,
-      expected_outcome: input.expectedOutcome,
-      assistant_response: input.assistantResponse,
-      chat_history_block: formatBlock('CHAT_HISTORY', input.chatHistory),
-      additional_context_block: formatBlock(
-        'ADDITIONAL_CONTEXT',
-        input.additionalContext,
-      ),
-      criteria_json: JSON.stringify(input.criteria, null, 2),
-    };
-    userContent = interpolate(input.userTemplate, vars);
-  } else {
-    userContent = buildDefaultJudgeUserMessage(input);
-  }
+  const vars: PlaceholderVars = {
+    question: input.question,
+    expected_outcome: input.expectedOutcome,
+    assistant_response: input.assistantResponse,
+    criteria_json: JSON.stringify(input.criteria, null, 2),
+  };
 
   return [
     { role: 'system', content: DEFAULT_JUDGE_SYSTEM_TEMPLATE },
-    { role: 'user', content: userContent },
+    { role: 'user', content: interpolate(DEFAULT_JUDGE_USER_TEMPLATE, vars) },
   ];
 }

--- a/src/lib/evaluation/evaluators/llm-judge/tests/llm-judge-evaluator.spec.ts
+++ b/src/lib/evaluation/evaluators/llm-judge/tests/llm-judge-evaluator.spec.ts
@@ -304,7 +304,9 @@ describe('performLlmJudgeEvaluation', () => {
       const result = await performLlmJudgeEvaluation(buildRequest());
 
       expect(result.passed).toBe(false);
-      expect(result.error).toContain('schema validation failed');
+      expect(result.error).toContain('Judge response invalid');
+      // The bullet points should reference the offending field path.
+      expect(result.error).toContain('criteria');
     });
 
     it('returns an error result when a score is out of range', async () => {
@@ -315,7 +317,9 @@ describe('performLlmJudgeEvaluation', () => {
       const result = await performLlmJudgeEvaluation(buildRequest());
 
       expect(result.passed).toBe(false);
-      expect(result.error).toContain('schema validation failed');
+      expect(result.error).toContain('Judge response invalid');
+      // The bullet point should pinpoint the score field at index 0.
+      expect(result.error).toContain('score');
     });
 
     it('returns an error result when the judge skips a criterion id', async () => {
@@ -359,31 +363,4 @@ describe('performLlmJudgeEvaluation', () => {
     });
   });
 
-  describe('context fields flow through to the prompt', () => {
-    beforeEach(() => {
-      mockJudge.mockResolvedValue({
-        criteria: [{ id: 'correctness', score: 0.9 }],
-      });
-    });
-
-    it('passes chatHistory into the judge messages as a CHAT_HISTORY block', async () => {
-      await performLlmJudgeEvaluation(
-        buildRequest({ chatHistory: 'user: hi\nassistant: hello' }),
-      );
-      expect(judgeUserContent()).toContain(
-        'CHAT_HISTORY:\nuser: hi\nassistant: hello',
-      );
-    });
-
-    it('passes additionalContext into the judge messages as an ADDITIONAL_CONTEXT block', async () => {
-      await performLlmJudgeEvaluation(
-        buildRequest({
-          additionalContext: 'Wikipedia snippet about France.',
-        }),
-      );
-      expect(judgeUserContent()).toContain(
-        'ADDITIONAL_CONTEXT:\nWikipedia snippet about France.',
-      );
-    });
-  });
 });

--- a/src/lib/evaluation/evaluators/llm-judge/tests/llm-judge-evaluator.spec.ts
+++ b/src/lib/evaluation/evaluators/llm-judge/tests/llm-judge-evaluator.spec.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { performLlmJudgeEvaluation } from '../llm-judge-evaluator';
+import {
+  EvaluationApproach,
+  DEFAULT_LLM_JUDGE_PASS_SCORE,
+} from '../../../constants';
+import type { EvaluationRequest } from '../../../types';
+import type {
+  JudgeMessage,
+  JudgeResponse,
+  LlmJudge,
+} from '../../../../../types/llm-test-runner';
+
+// Typed mock so `mockResolvedValue` / `mockRejectedValue` don't need `as any`.
+const mockJudge = jest.fn<LlmJudge>();
+
+function buildRequest(
+  overrides: Partial<EvaluationRequest> = {},
+): EvaluationRequest {
+  return {
+    testCaseId: 'tc-1',
+    question: 'What is the capital of France?',
+    expectedOutcome: 'Paris',
+    actualResponse: 'The capital is Paris.',
+    evaluationParameters: {
+      approach: EvaluationApproach.LLM_JUDGE,
+      criteria: [
+        { id: 'correctness', description: 'Factually correct.', weight: 1 },
+      ],
+    },
+    llmJudge: mockJudge,
+    ...overrides,
+  };
+}
+
+function judgeUserContent(): string {
+  // The 2nd message is always the user message; we use this to assert what
+  // was sent to the judge in flow-through tests.
+  const args = mockJudge.mock.calls[0][0] as { messages: JudgeMessage[] };
+  return args.messages[1].content;
+}
+
+describe('performLlmJudgeEvaluation', () => {
+  beforeEach(() => {
+    mockJudge.mockReset();
+  });
+
+  describe('happy path', () => {
+    it('returns passed=true with the judge score when above threshold', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [{ id: 'correctness', score: 0.9, reason: 'Correct.' }],
+      });
+
+      const result = await performLlmJudgeEvaluation(buildRequest());
+
+      expect(result.passed).toBe(true);
+      expect(result.evaluationApproachResult?.score).toBe(0.9);
+      expect(result.evaluationApproachResult?.approachUsed).toBe(
+        EvaluationApproach.LLM_JUDGE,
+      );
+      expect(result.error).toBeUndefined();
+    });
+
+    it('populates criterionResults with id, description, weight, score, reason', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [
+          { id: 'correctness', score: 0.8, reason: 'Mostly correct.' },
+        ],
+      });
+
+      const result = await performLlmJudgeEvaluation(buildRequest());
+
+      expect(result.criterionResults).toEqual([
+        {
+          id: 'correctness',
+          description: 'Factually correct.',
+          weight: 1,
+          score: 0.8,
+          reason: 'Mostly correct.',
+        },
+      ]);
+    });
+
+    it('preserves input criteria order in criterionResults regardless of judge response order', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [
+          { id: 'b', score: 0.5 },
+          { id: 'a', score: 0.9 },
+        ],
+      });
+
+      const result = await performLlmJudgeEvaluation(
+        buildRequest({
+          evaluationParameters: {
+            approach: EvaluationApproach.LLM_JUDGE,
+            criteria: [
+              { id: 'a', description: 'A', weight: 1 },
+              { id: 'b', description: 'B', weight: 1 },
+            ],
+          },
+        }),
+      );
+
+      expect(result.criterionResults?.map(c => c.id)).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('default criterion fallback', () => {
+    it('uses the default correctness criterion when criteria is undefined', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [{ id: 'correctness', score: 0.7 }],
+      });
+
+      const result = await performLlmJudgeEvaluation(
+        buildRequest({
+          evaluationParameters: {
+            approach: EvaluationApproach.LLM_JUDGE,
+          },
+        }),
+      );
+
+      expect(result.criterionResults?.[0].id).toBe('correctness');
+      // The default criterion id was sent to the judge in the user prompt.
+      expect(judgeUserContent()).toContain('"id": "correctness"');
+    });
+
+    it('uses the default correctness criterion when criteria is an empty array', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [{ id: 'correctness', score: 0.7 }],
+      });
+
+      const result = await performLlmJudgeEvaluation(
+        buildRequest({
+          evaluationParameters: {
+            approach: EvaluationApproach.LLM_JUDGE,
+            criteria: [],
+          },
+        }),
+      );
+
+      expect(result.criterionResults?.[0].id).toBe('correctness');
+    });
+  });
+
+  describe('weighted average', () => {
+    it('computes the weighted average correctly with uniform weights', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [
+          { id: 'a', score: 0.6 },
+          { id: 'b', score: 0.8 },
+        ],
+      });
+
+      const result = await performLlmJudgeEvaluation(
+        buildRequest({
+          evaluationParameters: {
+            approach: EvaluationApproach.LLM_JUDGE,
+            criteria: [
+              { id: 'a', description: 'A', weight: 1 },
+              { id: 'b', description: 'B', weight: 1 },
+            ],
+          },
+        }),
+      );
+
+      // (0.6×1 + 0.8×1) / 2 = 0.7
+      expect(result.evaluationApproachResult?.score).toBeCloseTo(0.7);
+    });
+
+    it('weights skewed criteria correctly', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [
+          { id: 'a', score: 0.3 },
+          { id: 'b', score: 0.9 },
+        ],
+      });
+
+      const result = await performLlmJudgeEvaluation(
+        buildRequest({
+          evaluationParameters: {
+            approach: EvaluationApproach.LLM_JUDGE,
+            criteria: [
+              { id: 'a', description: 'A', weight: 1 },
+              { id: 'b', description: 'B', weight: 3 },
+            ],
+          },
+        }),
+      );
+
+      // (0.3×1 + 0.9×3) / 4 = 3.0 / 4 = 0.75
+      expect(result.evaluationApproachResult?.score).toBeCloseTo(0.75);
+    });
+
+    it('defaults missing weight to 1', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [
+          { id: 'a', score: 1.0 },
+          { id: 'b', score: 0.0 },
+        ],
+      });
+
+      const result = await performLlmJudgeEvaluation(
+        buildRequest({
+          evaluationParameters: {
+            approach: EvaluationApproach.LLM_JUDGE,
+            criteria: [
+              { id: 'a', description: 'A' },
+              { id: 'b', description: 'B' },
+            ],
+          },
+        }),
+      );
+
+      // Both default to weight 1 → (1×1 + 0×1) / 2 = 0.5
+      expect(result.evaluationApproachResult?.score).toBeCloseTo(0.5);
+      expect(result.criterionResults?.map(c => c.weight)).toEqual([1, 1]);
+    });
+  });
+
+  describe('threshold and pass/fail', () => {
+    it('passes when score >= threshold', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [{ id: 'correctness', score: 0.7 }],
+      });
+
+      const result = await performLlmJudgeEvaluation(
+        buildRequest({
+          evaluationParameters: {
+            approach: EvaluationApproach.LLM_JUDGE,
+            threshold: 0.7,
+            criteria: [{ id: 'correctness', description: 'X', weight: 1 }],
+          },
+        }),
+      );
+
+      expect(result.passed).toBe(true);
+    });
+
+    it('fails when score < threshold', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [{ id: 'correctness', score: 0.6 }],
+      });
+
+      const result = await performLlmJudgeEvaluation(
+        buildRequest({
+          evaluationParameters: {
+            approach: EvaluationApproach.LLM_JUDGE,
+            threshold: 0.7,
+            criteria: [{ id: 'correctness', description: 'X', weight: 1 }],
+          },
+        }),
+      );
+
+      expect(result.passed).toBe(false);
+    });
+
+    it('defaults to DEFAULT_LLM_JUDGE_PASS_SCORE when threshold is undefined', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [{ id: 'correctness', score: 0.7 }],
+      });
+
+      const result = await performLlmJudgeEvaluation(
+        buildRequest({
+          evaluationParameters: {
+            approach: EvaluationApproach.LLM_JUDGE,
+            criteria: [{ id: 'correctness', description: 'X', weight: 1 }],
+          },
+        }),
+      );
+
+      expect(result.passed).toBe(true);
+      expect(result.evaluationParameters?.threshold).toBe(
+        DEFAULT_LLM_JUDGE_PASS_SCORE,
+      );
+    });
+  });
+
+  describe('error paths', () => {
+    it('returns an error result when the llmJudge callback is missing', async () => {
+      const result = await performLlmJudgeEvaluation(
+        buildRequest({ llmJudge: undefined }),
+      );
+
+      expect(result.passed).toBe(false);
+      expect(result.evaluationApproachResult?.score).toBe(0);
+      expect(result.error).toContain('llmJudge callback is required');
+    });
+
+    it('returns an error result when the judge throws', async () => {
+      mockJudge.mockRejectedValue(new Error('rate limited'));
+
+      const result = await performLlmJudgeEvaluation(buildRequest());
+
+      expect(result.passed).toBe(false);
+      expect(result.error).toContain('Judge call failed');
+      expect(result.error).toContain('rate limited');
+    });
+
+    it('returns an error result when judge returns a structurally invalid response', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: 'not an array',
+      } as unknown as JudgeResponse);
+
+      const result = await performLlmJudgeEvaluation(buildRequest());
+
+      expect(result.passed).toBe(false);
+      expect(result.error).toContain('schema validation failed');
+    });
+
+    it('returns an error result when a score is out of range', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [{ id: 'correctness', score: 1.5 }],
+      });
+
+      const result = await performLlmJudgeEvaluation(buildRequest());
+
+      expect(result.passed).toBe(false);
+      expect(result.error).toContain('schema validation failed');
+    });
+
+    it('returns an error result when the judge skips a criterion id', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [{ id: 'a', score: 0.9 }],
+      });
+
+      const result = await performLlmJudgeEvaluation(
+        buildRequest({
+          evaluationParameters: {
+            approach: EvaluationApproach.LLM_JUDGE,
+            criteria: [
+              { id: 'a', description: 'A', weight: 1 },
+              { id: 'b', description: 'B', weight: 1 },
+            ],
+          },
+        }),
+      );
+
+      expect(result.passed).toBe(false);
+      expect(result.error).toContain('missing scores for criteria: b');
+    });
+  });
+
+  describe('lenient on extras', () => {
+    it('silently drops extra criterion ids the judge invented', async () => {
+      mockJudge.mockResolvedValue({
+        criteria: [
+          { id: 'correctness', score: 0.9 },
+          { id: 'something_invented', score: 0.4 },
+        ],
+      });
+
+      const result = await performLlmJudgeEvaluation(buildRequest());
+
+      expect(result.passed).toBe(true);
+      expect(result.criterionResults).toHaveLength(1);
+      expect(result.criterionResults?.[0].id).toBe('correctness');
+      // Extras don't pollute the final score.
+      expect(result.evaluationApproachResult?.score).toBe(0.9);
+    });
+  });
+
+  describe('context fields flow through to the prompt', () => {
+    beforeEach(() => {
+      mockJudge.mockResolvedValue({
+        criteria: [{ id: 'correctness', score: 0.9 }],
+      });
+    });
+
+    it('passes chatHistory into the judge messages as a CHAT_HISTORY block', async () => {
+      await performLlmJudgeEvaluation(
+        buildRequest({ chatHistory: 'user: hi\nassistant: hello' }),
+      );
+      expect(judgeUserContent()).toContain(
+        'CHAT_HISTORY:\nuser: hi\nassistant: hello',
+      );
+    });
+
+    it('passes additionalContext into the judge messages as an ADDITIONAL_CONTEXT block', async () => {
+      await performLlmJudgeEvaluation(
+        buildRequest({
+          additionalContext: 'Wikipedia snippet about France.',
+        }),
+      );
+      expect(judgeUserContent()).toContain(
+        'ADDITIONAL_CONTEXT:\nWikipedia snippet about France.',
+      );
+    });
+  });
+});

--- a/src/lib/evaluation/field-evaluation-approach.spec.ts
+++ b/src/lib/evaluation/field-evaluation-approach.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  getAllowedApproachesForFieldType,
+  isApproachAllowedForFieldType,
+  normalizeEvaluationParametersForField,
+} from './field-evaluation-approach';
+import { EvaluationApproach } from './constants';
+
+describe('getAllowedApproachesForFieldType', () => {
+  it('locks select fields to exact only', () => {
+    const allowed = getAllowedApproachesForFieldType('select');
+    expect(allowed).toEqual([EvaluationApproach.EXACT]);
+  });
+
+  it('allows all six approaches for textarea fields', () => {
+    const allowed = getAllowedApproachesForFieldType('textarea');
+    expect(allowed).toContain(EvaluationApproach.EXACT);
+    expect(allowed).toContain(EvaluationApproach.SEMANTIC);
+    expect(allowed).toContain(EvaluationApproach.ROUGE_1);
+    expect(allowed).toContain(EvaluationApproach.ROUGE_L);
+    expect(allowed).toContain(EvaluationApproach.BLEU);
+    expect(allowed).toContain(EvaluationApproach.LLM_JUDGE);
+  });
+
+  it('allows llm-judge for text fields', () => {
+    expect(getAllowedApproachesForFieldType('text')).toContain(
+      EvaluationApproach.LLM_JUDGE,
+    );
+  });
+
+  it('allows llm-judge for chips-input fields', () => {
+    expect(getAllowedApproachesForFieldType('chips-input')).toContain(
+      EvaluationApproach.LLM_JUDGE,
+    );
+  });
+
+  it('does NOT allow llm-judge for select fields', () => {
+    expect(getAllowedApproachesForFieldType('select')).not.toContain(
+      EvaluationApproach.LLM_JUDGE,
+    );
+  });
+});
+
+describe('isApproachAllowedForFieldType', () => {
+  it('returns true for llm-judge on textarea', () => {
+    expect(
+      isApproachAllowedForFieldType('textarea', EvaluationApproach.LLM_JUDGE),
+    ).toBe(true);
+  });
+
+  it('returns false for llm-judge on select', () => {
+    expect(
+      isApproachAllowedForFieldType('select', EvaluationApproach.LLM_JUDGE),
+    ).toBe(false);
+  });
+
+  it('returns true for exact on select', () => {
+    expect(
+      isApproachAllowedForFieldType('select', EvaluationApproach.EXACT),
+    ).toBe(true);
+  });
+});
+
+describe('normalizeEvaluationParametersForField', () => {
+  it('keeps a valid approach untouched', () => {
+    const result = normalizeEvaluationParametersForField('textarea', {
+      approach: EvaluationApproach.LLM_JUDGE,
+      threshold: 0.7,
+    });
+    expect(result.approach).toBe(EvaluationApproach.LLM_JUDGE);
+    expect(result.threshold).toBe(0.7);
+  });
+
+  it('snaps llm-judge back to exact on select fields', () => {
+    const result = normalizeEvaluationParametersForField('select', {
+      approach: EvaluationApproach.LLM_JUDGE,
+    });
+    expect(result.approach).toBe(EvaluationApproach.EXACT);
+  });
+
+  it('snaps any non-exact approach back to exact on select fields', () => {
+    expect(
+      normalizeEvaluationParametersForField('select', {
+        approach: EvaluationApproach.ROUGE_1,
+      }).approach,
+    ).toBe(EvaluationApproach.EXACT);
+
+    expect(
+      normalizeEvaluationParametersForField('select', {
+        approach: EvaluationApproach.SEMANTIC,
+      }).approach,
+    ).toBe(EvaluationApproach.EXACT);
+  });
+
+  it('preserves other params (threshold, criteria) when the approach itself is valid', () => {
+    const result = normalizeEvaluationParametersForField('textarea', {
+      approach: EvaluationApproach.LLM_JUDGE,
+      threshold: 0.85,
+      criteria: [{ id: 'correctness', description: 'Factually correct.' }],
+    });
+    expect(result.threshold).toBe(0.85);
+    expect(result.criteria).toEqual([
+      { id: 'correctness', description: 'Factually correct.' },
+    ]);
+  });
+
+  it('falls back to the first allowed approach when params are undefined', () => {
+    expect(
+      normalizeEvaluationParametersForField('select', undefined).approach,
+    ).toBe(EvaluationApproach.EXACT);
+  });
+});

--- a/src/lib/evaluation/types.ts
+++ b/src/lib/evaluation/types.ts
@@ -2,7 +2,7 @@ import {
   EvaluationParameters,
   EvaluationApproachResult,
 } from '../../types/evaluation';
-import type { ExpectedOutcomeFieldType } from '../../types/llm-test-runner';
+import type { ExpectedOutcomeFieldType, LlmJudge } from '../../types/llm-test-runner';
 
 export interface EvaluationRequest {
   testCaseId: string;
@@ -10,6 +10,9 @@ export interface EvaluationRequest {
   expectedOutcome: string;
   actualResponse: string;
   evaluationParameters: EvaluationParameters;
+  llmJudge?: LlmJudge;
+  chatHistory?: string;
+  additionalContext?: string;
 }
 
 export interface FieldEvaluationInput {
@@ -25,6 +28,9 @@ export interface EvaluationRequestV2 {
   testCaseId: string;
   question: string;
   fields: FieldEvaluationInput[];
+  llmJudge?: LlmJudge;
+  chatHistory?: string;
+  additionalContext?: string;
 }
 
 export interface EvaluationResult {
@@ -35,6 +41,15 @@ export interface EvaluationResult {
   timestamp?: string;
   evaluationParameters?: EvaluationParameters;
   evaluationApproachResult?: EvaluationApproachResult;
+  criterionResults?: CriterionResult[];
+  /**
+   * Populated by evaluators (currently llm-judge) when evaluation fails for a
+   * recoverable reason — e.g. judge call threw, response failed schema
+   * validation, criterion coverage check failed. The engine maps this onto
+   * the corresponding `FieldEvaluationResult.error` so the existing
+   * evaluation-row UI can render it.
+   */
+  error?: string;
 }
 
 export interface FieldEvaluationResult {
@@ -71,4 +86,12 @@ export interface Rouge1OverallDetails {
   passRate: string;
   thresholdUsed: number;
   approach: string;
+}
+
+export interface CriterionResult {
+  id: string;
+  description: string;
+  weight: number;
+  score: number;
+  reason?: string;
 }

--- a/src/lib/evaluation/types.ts
+++ b/src/lib/evaluation/types.ts
@@ -63,6 +63,7 @@ export interface FieldEvaluationResult {
   evaluationApproachResult: EvaluationApproachResult;
   error?: string;
   warning?: string;
+  criterionResults?: CriterionResult[];
 }
 
 export interface KeywordMatch {

--- a/src/lib/evaluation/types.ts
+++ b/src/lib/evaluation/types.ts
@@ -11,8 +11,6 @@ export interface EvaluationRequest {
   actualResponse: string;
   evaluationParameters: EvaluationParameters;
   llmJudge?: LlmJudge;
-  chatHistory?: string;
-  additionalContext?: string;
 }
 
 export interface FieldEvaluationInput {
@@ -29,8 +27,6 @@ export interface EvaluationRequestV2 {
   question: string;
   fields: FieldEvaluationInput[];
   llmJudge?: LlmJudge;
-  chatHistory?: string;
-  additionalContext?: string;
 }
 
 export interface EvaluationResult {

--- a/src/lib/form/components/app-select.css
+++ b/src/lib/form/components/app-select.css
@@ -1,7 +1,3 @@
-.app-select {
-  margin-bottom: var(--spacing-4);
-}
-
 .app-select__label {
   display: block;
   margin-bottom: var(--spacing-2);

--- a/src/lib/test-cases/test-case-mutations.spec.ts
+++ b/src/lib/test-cases/test-case-mutations.spec.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from '@jest/globals';
 import { applyExpectedOutcomeChange } from './test-case-mutations';
 import { EvaluationApproach } from '../evaluation/constants';
-import type { TestCase } from '../../types/llm-test-runner';
+import type { Criterion, TestCase } from '../../types/llm-test-runner';
 
 function buildTestCase(
   approach: EvaluationApproach | undefined,
   threshold?: number,
+  criteria?: Criterion[],
 ): TestCase {
   return {
     id: 'tc-1',
@@ -17,7 +18,11 @@ function buildTestCase(
         value: 'Paris',
         outcomeMode: 'static',
         evaluationParameters: approach
-          ? { approach, ...(threshold !== undefined ? { threshold } : {}) }
+          ? {
+              approach,
+              ...(threshold !== undefined ? { threshold } : {}),
+              ...(criteria !== undefined ? { criteria } : {}),
+            }
           : undefined,
       },
     ],
@@ -93,6 +98,91 @@ describe('applyExpectedOutcomeChange — set-evaluation-threshold', () => {
       index: 99,
       operation: 'set-evaluation-threshold',
       value: 0.3,
+    });
+
+    expect(after).toBe(before);
+  });
+});
+
+describe('applyExpectedOutcomeChange — set-evaluation-criteria', () => {
+  const sampleCriteria: Criterion[] = [
+    { id: 'correctness', description: 'Factually correct.' },
+    { id: 'concision', description: 'Concise and on point.' },
+  ];
+
+  it('sets the criteria array while preserving the existing approach and threshold', () => {
+    const before = buildTestCase(EvaluationApproach.LLM_JUDGE, 0.7);
+
+    const after = applyExpectedOutcomeChange(before, {
+      index: 0,
+      operation: 'set-evaluation-criteria',
+      value: sampleCriteria,
+    });
+
+    expect(after.expectedOutcome[0].evaluationParameters).toEqual({
+      approach: EvaluationApproach.LLM_JUDGE,
+      threshold: 0.7,
+      criteria: sampleCriteria,
+    });
+  });
+
+  it('overwrites existing criteria when called with a new array', () => {
+    const before = buildTestCase(EvaluationApproach.LLM_JUDGE, undefined, [
+      { id: 'old', description: 'Old criterion.' },
+    ]);
+    const newCriteria: Criterion[] = [
+      { id: 'fresh', description: 'Fresh criterion.' },
+    ];
+
+    const after = applyExpectedOutcomeChange(before, {
+      index: 0,
+      operation: 'set-evaluation-criteria',
+      value: newCriteria,
+    });
+
+    expect(
+      after.expectedOutcome[0].evaluationParameters?.criteria,
+    ).toEqual(newCriteria);
+  });
+
+  it('clears the criteria when value is undefined and drops the key entirely', () => {
+    const before = buildTestCase(EvaluationApproach.LLM_JUDGE, undefined, [
+      { id: 'correctness', description: 'Factually correct.' },
+    ]);
+
+    const after = applyExpectedOutcomeChange(before, {
+      index: 0,
+      operation: 'set-evaluation-criteria',
+      value: undefined,
+    });
+
+    const params = after.expectedOutcome[0].evaluationParameters;
+    expect(params).toEqual({ approach: EvaluationApproach.LLM_JUDGE });
+    // Make sure we didn't just leave `criteria: undefined` — that would
+    // leak into serialised JSON and confuse downstream consumers.
+    expect(params && 'criteria' in params).toBe(false);
+  });
+
+  it('does nothing when the field has no evaluation approach yet', () => {
+    const before = buildTestCase(undefined);
+
+    const after = applyExpectedOutcomeChange(before, {
+      index: 0,
+      operation: 'set-evaluation-criteria',
+      value: sampleCriteria,
+    });
+
+    // Same instance returned (no-op for orphaned criteria).
+    expect(after).toBe(before);
+  });
+
+  it('returns the original test case for an out-of-range index', () => {
+    const before = buildTestCase(EvaluationApproach.LLM_JUDGE);
+
+    const after = applyExpectedOutcomeChange(before, {
+      index: 99,
+      operation: 'set-evaluation-criteria',
+      value: sampleCriteria,
     });
 
     expect(after).toBe(before);

--- a/src/lib/test-cases/test-case-mutations.ts
+++ b/src/lib/test-cases/test-case-mutations.ts
@@ -3,6 +3,7 @@ import {
   type ExpectedOutcomeField,
   type EvaluationSource,
   type ExpectedOutcomeMode,
+  type Criterion,
 } from '../../types/llm-test-runner';
 import { EvaluationApproach } from '../evaluation/constants';
 import { normalizeEvaluationParametersForField } from '../evaluation/field-evaluation-approach';
@@ -72,6 +73,11 @@ export type ExpectedOutcomeChange =
       index: number;
       operation: 'set-evaluation-source-extractor';
       value: string;
+    }
+  | {
+      index: number;
+      operation: 'set-evaluation-criteria';
+      value: Criterion[] | undefined; // clears the criteria override, evaluator falls back to its default correctness criterion.
     };
 
 export function applyExpectedOutcomeChange(
@@ -184,6 +190,8 @@ export function applyExpectedOutcomeChange(
         },
       });
     }
+    case 'set-evaluation-criteria':
+      return updateExpectedOutcomeFieldCriteria(testCase, index, change.value);
   }
 }
 
@@ -249,6 +257,32 @@ export function updateExpectedOutcomeFieldThreshold(
     evaluationParameters,
   };
 
+  return {
+    ...testCase,
+    expectedOutcome,
+  };
+}
+export function updateExpectedOutcomeFieldCriteria(testCase: TestCase, fieldIndex: number, criteria: Criterion[] | undefined): TestCase {
+  const expectedOutcome = [...(testCase.expectedOutcome || [])];
+  const target = expectedOutcome[fieldIndex];
+
+  if (!target) {
+    return testCase;
+  }
+  const currentApproach = target.evaluationParameters?.approach;
+  if (!currentApproach) {
+    return testCase;
+  }
+  const { criteria: _drop, ...restParams } =
+       target.evaluationParameters ?? { approach: currentApproach };
+  const evaluationParameters = criteria
+    ? { ...restParams, approach: currentApproach, criteria }
+    : { ...restParams, approach: currentApproach };
+  
+  expectedOutcome[fieldIndex] = {
+    ...target,
+    evaluationParameters,
+  };
   return {
     ...testCase,
     expectedOutcome,

--- a/src/lib/ui/criteria-input/criteria-input.css
+++ b/src/lib/ui/criteria-input/criteria-input.css
@@ -1,0 +1,47 @@
+.criteria-input {
+  display: flex;
+  flex-direction: column;
+}
+
+.criteria-input__label {
+  display: block;
+  margin-bottom: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--foreground);
+}
+
+.criteria-input__textarea {
+  width: 95%;
+  box-sizing: border-box;
+  padding: var(--spacing-3);
+  border: 2px solid var(--input);
+  border-radius: var(--radius);
+  font-size: var(--font-size-sm);
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.2s ease;
+  font-family: inherit;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.criteria-input__textarea:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.criteria-input__textarea--error {
+  border-color: var(--destructive);
+}
+
+.criteria-input__textarea--error:focus {
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1);
+}
+
+.criteria-input__error {
+  margin-top: var(--spacing-2);
+  color: var(--destructive);
+  font-size: var(--font-size-xs);
+  line-height: 1.3;
+}

--- a/src/lib/ui/criteria-input/criteria-input.spec.tsx
+++ b/src/lib/ui/criteria-input/criteria-input.spec.tsx
@@ -1,0 +1,244 @@
+import { jest, describe, it, expect } from '@jest/globals';
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+import { CriteriaInput, type CriteriaInputChangeDetail } from './criteria-input';
+
+type SpecPage = Awaited<ReturnType<typeof newSpecPage>>;
+
+function getTextarea(page: SpecPage): HTMLTextAreaElement {
+  return page.root!.shadowRoot!.querySelector(
+    '.criteria-input__textarea',
+  ) as HTMLTextAreaElement;
+}
+
+function getTextareaValue(page: SpecPage): string {
+  return getTextarea(page).getAttribute('value') ?? '';
+}
+
+function getError(page: SpecPage): HTMLElement | null {
+  return page.root!.shadowRoot!.querySelector(
+    '.criteria-input__error',
+  ) as HTMLElement | null;
+}
+
+async function type(page: SpecPage, raw: string): Promise<void> {
+  const textarea = getTextarea(page);
+  textarea.value = raw;
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  await page.waitForChanges();
+}
+
+function attachChangeSpy(
+  page: SpecPage,
+): jest.Mock<(e: CustomEvent<CriteriaInputChangeDetail>) => void> {
+  const spy = jest.fn<(e: CustomEvent<CriteriaInputChangeDetail>) => void>();
+  page.root!.addEventListener('criteriaChange', (e: Event) =>
+    spy(e as CustomEvent<CriteriaInputChangeDetail>),
+  );
+  return spy;
+}
+
+const VALID_JSON = `[
+  {"id": "correctness", "description": "Factually correct.", "weight": 1}
+]`;
+
+describe('CriteriaInput', () => {
+  describe('initial render', () => {
+    it('initializes textarea with the criteria prop pretty-printed', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        template: () => (
+          <criteria-input
+            criteria={[
+              { id: 'a', description: 'A criterion.', weight: 2 },
+            ]}
+          />
+        ),
+      });
+      const text = getTextareaValue(page);
+      expect(text).toContain('"id": "a"');
+      expect(text).toContain('"weight": 2');
+    });
+
+    it('renders an empty textarea when criteria is undefined', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      expect(getTextareaValue(page)).toBe('');
+    });
+
+    it('shows no error initially', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      expect(getError(page)).toBeNull();
+    });
+  });
+
+  describe('valid input', () => {
+    it('emits criteriaChange with parsed array on valid JSON', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      const spy = attachChangeSpy(page);
+      await type(page, VALID_JSON);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0].detail.value).toEqual([
+        { id: 'correctness', description: 'Factually correct.', weight: 1 },
+      ]);
+      expect(getError(page)).toBeNull();
+    });
+
+    it('emits criteriaChange with undefined when text is cleared', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        template: () => (
+          <criteria-input
+            criteria={[{ id: 'a', description: 'A.', weight: 1 }]}
+          />
+        ),
+      });
+      const spy = attachChangeSpy(page);
+      await type(page, '');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0].detail.value).toBeUndefined();
+      expect(getError(page)).toBeNull();
+    });
+
+    it('accepts optional weight (defaults handled by evaluator)', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      const spy = attachChangeSpy(page);
+      await type(
+        page,
+        '[{"id": "a", "description": "Just an A criterion."}]',
+      );
+      expect(spy.mock.calls[0][0].detail.value).toEqual([
+        { id: 'a', description: 'Just an A criterion.' },
+      ]);
+    });
+  });
+
+  describe('invalid input', () => {
+    it('shows an inline error and does NOT emit on invalid JSON', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      const spy = attachChangeSpy(page);
+      await type(page, '[{"id": "a"');
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(getError(page)?.textContent).toContain('Invalid JSON');
+    });
+
+    it('rejects non-array JSON', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      const spy = attachChangeSpy(page);
+      await type(page, '{"id": "a", "description": "not an array"}');
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(getError(page)?.textContent).toContain('must be a JSON array');
+    });
+
+    it('rejects empty array', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      const spy = attachChangeSpy(page);
+      await type(page, '[]');
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(getError(page)?.textContent).toContain(
+        'At least one criterion is required',
+      );
+    });
+
+    it('rejects criterion missing id', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      const spy = attachChangeSpy(page);
+      await type(page, '[{"description": "no id"}]');
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(getError(page)?.textContent).toContain('"id" must be a non-empty string');
+    });
+
+    it('rejects criterion missing description', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      const spy = attachChangeSpy(page);
+      await type(page, '[{"id": "a"}]');
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(getError(page)?.textContent).toContain(
+        '"description" must be a non-empty string',
+      );
+    });
+
+    it('rejects negative weight', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      const spy = attachChangeSpy(page);
+      await type(
+        page,
+        '[{"id": "a", "description": "x", "weight": -1}]',
+      );
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(getError(page)?.textContent).toContain(
+        '"weight" must be a positive number',
+      );
+    });
+
+    it('rejects duplicate ids', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      const spy = attachChangeSpy(page);
+      await type(
+        page,
+        '[{"id":"a","description":"x"},{"id":"a","description":"y"}]',
+      );
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(getError(page)?.textContent).toContain('duplicate id "a"');
+    });
+  });
+
+  describe('recovery from error', () => {
+    it('clears the error and re-emits when JSON becomes valid again', async () => {
+      const page = await newSpecPage({
+        components: [CriteriaInput],
+        html: '<criteria-input></criteria-input>',
+      });
+      const spy = attachChangeSpy(page);
+
+      await type(page, '[{');
+      expect(getError(page)).not.toBeNull();
+      expect(spy).not.toHaveBeenCalled();
+
+      await type(page, VALID_JSON);
+      expect(getError(page)).toBeNull();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/lib/ui/criteria-input/criteria-input.tsx
+++ b/src/lib/ui/criteria-input/criteria-input.tsx
@@ -1,0 +1,158 @@
+import {
+  Component,
+  Event,
+  EventEmitter,
+  Prop,
+  State,
+  Watch,
+  h,
+} from '@stencil/core';
+import type { Criterion } from '../../../schemas/expected-outcome';
+
+export interface CriteriaInputChangeDetail {
+  value: Criterion[] | undefined;
+}
+
+const PLACEHOLDER = `[
+  {
+    "id": "correctness",
+    "description": "Determine whether the actual output is factually correct based on the expected output.",
+    "weight": 1
+  }
+]`;
+
+function validateCriteriaArray(
+  value: unknown,
+): { criteria: Criterion[]; error?: undefined } | { error: string } {
+  if (!Array.isArray(value)) {
+    return { error: 'Criteria must be a JSON array.' };
+  }
+  if (value.length === 0) {
+    return { error: 'At least one criterion is required.' };
+  }
+  const seenIds = new Set<string>();
+  for (const [i, item] of value.entries()) {
+    if (typeof item !== 'object' || item === null) {
+      return { error: `Criterion ${i}: must be an object.` };
+    }
+    const c = item as Record<string, unknown>;
+    if (typeof c.id !== 'string' || c.id.trim().length === 0) {
+      return { error: `Criterion ${i}: "id" must be a non-empty string.` };
+    }
+    if (typeof c.description !== 'string' || c.description.trim().length === 0) {
+      return {
+        error: `Criterion ${i}: "description" must be a non-empty string.`,
+      };
+    }
+    if (c.weight !== undefined) {
+      if (
+        typeof c.weight !== 'number' ||
+        !Number.isFinite(c.weight) ||
+        c.weight <= 0
+      ) {
+        return { error: `Criterion ${i}: "weight" must be a positive number.` };
+      }
+    }
+    if (seenIds.has(c.id)) {
+      return { error: `Criterion ${i}: duplicate id "${c.id}".` };
+    }
+    seenIds.add(c.id);
+  }
+  return { criteria: value as Criterion[] };
+}
+
+@Component({
+  tag: 'criteria-input',
+  styleUrl: 'criteria-input.css',
+  shadow: true,
+})
+export class CriteriaInput {
+  @Prop() criteria?: Criterion[];
+
+  @Event({ bubbles: true, composed: true })
+  criteriaChange: EventEmitter<CriteriaInputChangeDetail>;
+
+  @State() text: string = '';
+  @State() error?: string;
+
+  componentWillLoad() {
+    this.text = this.criteria
+      ? JSON.stringify(this.criteria, null, 2)
+      : '';
+  }
+
+  @Watch('criteria')
+  onCriteriaPropChange(newValue: Criterion[] | undefined) {
+    if (this.error) {
+      return;
+    }
+    const propStr = JSON.stringify(newValue ?? []);
+    let localStr = '[]';
+    try {
+      localStr = JSON.stringify(JSON.parse(this.text || '[]'));
+    } catch {
+      this.text = newValue ? JSON.stringify(newValue, null, 2) : '';
+      return;
+    }
+    if (propStr !== localStr) {
+      this.text = newValue ? JSON.stringify(newValue, null, 2) : '';
+    }
+  }
+
+  private onInput = (e: Event) => {
+    const value = (e.target as HTMLTextAreaElement).value;
+    this.text = value;
+
+    if (!value.trim()) {
+      this.error = undefined;
+      this.criteriaChange.emit({ value: undefined });
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch (err) {
+      this.error = `Invalid JSON: ${err instanceof Error ? err.message : String(err)}`;
+      return;
+    }
+
+    const validation = validateCriteriaArray(parsed);
+    if ('error' in validation) {
+      this.error = validation.error;
+      return;
+    }
+    this.error = undefined;
+    this.criteriaChange.emit({ value: validation.criteria });
+  };
+
+  render() {
+    return (
+      <div class="criteria-input">
+        <label class="criteria-input__label" htmlFor="criteria-input-textarea">
+          Criteria (JSON)
+        </label>
+        <textarea
+          id="criteria-input-textarea"
+          class={
+            'criteria-input__textarea' +
+            (this.error ? ' criteria-input__textarea--error' : '')
+          }
+          rows={8}
+          placeholder={PLACEHOLDER}
+          aria-label="Criteria JSON"
+          aria-invalid={this.error ? 'true' : 'false'}
+          aria-describedby={this.error ? 'criteria-input-error' : undefined}
+          value={this.text}
+          onInput={this.onInput}
+        />
+
+        {this.error && (
+          <div id="criteria-input-error" class="criteria-input__error" role="alert">
+            {this.error}
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/src/schemas/expected-outcome.schema.spec.ts
+++ b/src/schemas/expected-outcome.schema.spec.ts
@@ -116,3 +116,150 @@ describe('expected outcome schemas', () => {
     ).toThrow('Extractor "missing-extractor" is not registered.');
   });
 });
+
+describe('expected outcome schemas — criteria (LLM Judge)', () => {
+  it('accepts evaluationParameters with a valid criteria array', () => {
+    const data = expectedOutcomeFieldSchema.parse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: 'answer',
+      evaluationParameters: {
+        approach: 'llm-judge',
+        threshold: 0.7,
+        criteria: [
+          { id: 'correctness', description: 'Factually correct.', weight: 2 },
+          { id: 'relevancy', description: 'Answers the prompt.' },
+        ],
+      },
+    });
+
+    expect(data.type).toBe('textarea');
+    if (data.type !== 'textarea') return;
+    expect(data.evaluationParameters?.criteria).toHaveLength(2);
+    expect(data.evaluationParameters?.criteria?.[0]).toEqual({
+      id: 'correctness',
+      description: 'Factually correct.',
+      weight: 2,
+    });
+    expect(data.evaluationParameters?.criteria?.[1].weight).toBeUndefined();
+  });
+
+  it('treats criteria as optional on evaluationParameters', () => {
+    const data = expectedOutcomeFieldSchema.parse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: 'answer',
+      evaluationParameters: { approach: 'llm-judge' },
+    });
+
+    expect(data.type).toBe('textarea');
+    if (data.type !== 'textarea') return;
+    expect(data.evaluationParameters?.criteria).toBeUndefined();
+  });
+
+  it('rejects a criterion with an empty id', () => {
+    const parsed = expectedOutcomeFieldSchema.safeParse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: 'answer',
+      evaluationParameters: {
+        approach: 'llm-judge',
+        criteria: [{ id: '   ', description: 'desc' }],
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a criterion with an empty description', () => {
+    const parsed = expectedOutcomeFieldSchema.safeParse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: 'answer',
+      evaluationParameters: {
+        approach: 'llm-judge',
+        criteria: [{ id: 'correctness', description: '   ' }],
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a criterion with weight 0', () => {
+    const parsed = expectedOutcomeFieldSchema.safeParse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: 'answer',
+      evaluationParameters: {
+        approach: 'llm-judge',
+        criteria: [{ id: 'correctness', description: 'desc', weight: 0 }],
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a criterion with a negative weight', () => {
+    const parsed = expectedOutcomeFieldSchema.safeParse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: 'answer',
+      evaluationParameters: {
+        approach: 'llm-judge',
+        criteria: [{ id: 'correctness', description: 'desc', weight: -0.5 }],
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('accepts a criterion with weight omitted (default applied later by evaluator)', () => {
+    const data = expectedOutcomeFieldSchema.parse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: 'answer',
+      evaluationParameters: {
+        approach: 'llm-judge',
+        criteria: [{ id: 'correctness', description: 'desc' }],
+      },
+    });
+
+    expect(data.type).toBe('textarea');
+    if (data.type !== 'textarea') return;
+    expect(data.evaluationParameters?.criteria?.[0].weight).toBeUndefined();
+  });
+
+  it('rejects two criteria with the same id', () => {
+    const parsed = expectedOutcomeFieldSchema.safeParse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: 'answer',
+      evaluationParameters: {
+        approach: 'llm-judge',
+        criteria: [
+          { id: 'correctness', description: 'first' },
+          { id: 'correctness', description: 'second' },
+        ],
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('accepts criteria on a non-llm-judge approach (orphan field, not enforced at schema level)', () => {
+    const data = expectedOutcomeFieldSchema.parse({
+      type: 'textarea' as const,
+      label: 'Expected Outcome',
+      value: 'answer',
+      evaluationParameters: {
+        approach: 'rouge-1',
+        threshold: 0.7,
+        criteria: [{ id: 'correctness', description: 'desc' }],
+      },
+    });
+
+    expect(data.type).toBe('textarea');
+    if (data.type !== 'textarea') return;
+    expect(data.evaluationParameters?.criteria).toHaveLength(1);
+  });
+});

--- a/src/schemas/expected-outcome.ts
+++ b/src/schemas/expected-outcome.ts
@@ -15,6 +15,11 @@ const customEvaluationSourceSchema = z.object({
   type: z.literal('custom'),
   extractorId: nonEmptyString,
 });
+const criterionSchema = z.object({
+  id: nonEmptyString,
+  description: nonEmptyString,
+  weight: z.number().positive().optional()
+});
 
 export const evaluationSourceExtractorSchema = z.custom<
   (payload: ModelResponsePayload) => string | Promise<string>
@@ -42,10 +47,23 @@ export type EvaluationSourceExtractor = z.infer<
 export type EvaluationSourceExtractors = z.infer<
   typeof evaluationSourceExtractorsSchema
 >;
+export type Criterion = z.infer<typeof criterionSchema>;
 
 const evaluationParametersSchema = z.object({
   approach: z.enum(EvaluationApproach),
   threshold: optionalNumber,
+  criteria: z
+    .array(criterionSchema)
+    .superRefine((val, ctx) => {
+      const ids = val.map(c => c.id);
+      if (ids.length !== new Set(ids).size) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'criteria ids must be unique.',
+        });
+      }
+    })
+    .optional(),
 });
 
 const selectEvaluationParametersSchema = evaluationParametersSchema.superRefine(

--- a/src/services/models/gemini.ts
+++ b/src/services/models/gemini.ts
@@ -8,6 +8,15 @@ export const enum GeminiModels {
   Gemini3Flash__Preview = 'gemini-3-flash-preview',
 }
 
+export interface GeminiInvokeInput {
+  /** The user prompt for this turn. */
+  prompt: string;
+  /** Optional system instructions, sent via Gemini's first-class
+   * `systemInstruction` config (NOT concatenated into the user prompt).
+   * Used by the judge wiring to keep system + user separated. */
+  system?: string;
+}
+
 export class GeminiAdapter implements LlmAdapter {
   private readonly sdk;
 
@@ -17,10 +26,24 @@ export class GeminiAdapter implements LlmAdapter {
     });
   }
 
-  async invoke(text: string) {
+  /**
+   * Generate content from Gemini.
+   *
+   * Accepts either a plain prompt string (single-turn call) or a
+   * structured input with explicit system instructions. Structured input
+   * lets Gemini treat the system prompt as a first-class directive
+   * rather than concatenated user text.
+   */
+  async invoke(input: string | GeminiInvokeInput) {
+    const params: GeminiInvokeInput =
+      typeof input === 'string' ? { prompt: input } : input;
+
     const response = await this.sdk.models.generateContent({
       model: GeminiModels.Gemini3Flash__Preview,
-      contents: text,
+      contents: params.prompt,
+      config: params.system
+        ? { systemInstruction: params.system }
+        : undefined,
     });
 
     return response.text;

--- a/src/types/evaluation.ts
+++ b/src/types/evaluation.ts
@@ -1,8 +1,10 @@
 import { EvaluationApproach } from '../lib/evaluation/constants'; 
+import { Criterion } from '../schemas/expected-outcome';
 
 export interface EvaluationParameters {
   approach: EvaluationApproach;
   threshold?: number;
+  criteria?: Criterion[];
 }
 
 export interface EvaluationApproachResult {

--- a/src/types/expected-outcome.ts
+++ b/src/types/expected-outcome.ts
@@ -1,4 +1,5 @@
 export type {
+  Criterion,
   EvaluationSource,
   EvaluationSourceExtractor,
   EvaluationSourceExtractors,

--- a/src/types/llm-test-runner.ts
+++ b/src/types/llm-test-runner.ts
@@ -2,6 +2,7 @@ import type { TestCase } from './test-case';
 import type { ModelResponsePayload } from '../schemas/model-response';
 
 export type {
+  Criterion,
   EvaluationSource,
   EvaluationSourceExtractor,
   EvaluationSourceExtractors,
@@ -40,3 +41,15 @@ export interface SavePayload {
   timestamp: string;
   testCases: TestCase[];
 }
+
+export interface JudgeMessage { role: 'system' | 'user'; content: string };
+export interface JudgeResponse {
+  criteria: Array<{
+    id: string;
+    score: number;
+    reason?: string;
+  }>;
+};
+export interface LlmJudge {
+  (input: {messages: JudgeMessage[]}): Promise<JudgeResponse>;
+};


### PR DESCRIPTION
This PR adds `llm-judge` to the existing evaluation approaches

## New public API

- `EvaluationApproach.LLM_JUDGE = 'llm-judge'`
- `Criterion` type (`{ id, description, weight? }`) — unique-id-validated by Zod, `weight` defaults to 1
- New runner prop on `<llm-test-runner>`:
```ts
  llmJudge?: (input: { messages: JudgeMessage[] }) => Promise;
```
  Required only when any test case uses `llm-judge`.
- `EvaluationResult.error` and `EvaluationResult.criterionResults` (also propagated to `FieldEvaluationResult`) for the existing summary UI.