### PR TITLE
UI revamp v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 www/
 loader/
+graphify-out
 
 *~
 *.sw[mnpcod]

--- a/src/components/llm-test-runner/header/llm-test-runner-header.css
+++ b/src/components/llm-test-runner/header/llm-test-runner-header.css
@@ -48,6 +48,38 @@
   display: none;
 }
 
+/* "Show summary" checkbox toggle */
+.test-runner-header__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  cursor: pointer;
+  user-select: none;
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: var(--radius-md);
+  color: var(--muted-foreground);
+  transition: color 150ms ease, background-color 150ms ease;
+}
+
+.test-runner-header__toggle:hover {
+  color: var(--foreground);
+  background: var(--muted);
+}
+
+.test-runner-header__toggle-input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  cursor: pointer;
+  accent-color: var(--primary);
+}
+
+.test-runner-header__toggle-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-snug);
+}
+
 /* Responsive Design */
 @media (max-width: 768px) /* var(--breakpoint-md) */ {
   .test-runner-header {

--- a/src/components/llm-test-runner/header/llm-test-runner-header.css
+++ b/src/components/llm-test-runner/header/llm-test-runner-header.css
@@ -3,11 +3,15 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--spacing-5) var(--spacing-6);
+  gap: var(--spacing-4);
+  padding: var(--spacing-3) var(--spacing-5);
   background: var(--background);
   color: var(--foreground);
-  box-shadow: var(--shadow-md);
   border-bottom: var(--border-width) solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: var(--z-sticky);
+  box-shadow: var(--shadow-sm);
 }
 
 /* Header Elements */

--- a/src/components/llm-test-runner/header/llm-test-runner-header.tsx
+++ b/src/components/llm-test-runner/header/llm-test-runner-header.tsx
@@ -18,12 +18,14 @@ export interface LLMTestRunnerHeaderProps {
   useSave?: boolean;
   isSaving?: boolean;
   usePromptEditor?: boolean;
+  showSummary: boolean;
   onImport: (file: File) => void;
   onExportSuite: () => void;
   onExportResults: () => void;
   onRunAll: () => void;
   onSave?: () => void;
   onAddTestCase: () => void;
+  onToggleSummary: (show: boolean) => void;
 }
 
 export const LLMTestRunnerHeader: FunctionalComponent<
@@ -35,12 +37,14 @@ export const LLMTestRunnerHeader: FunctionalComponent<
   useSave = false,
   isSaving = false,
   usePromptEditor = false,
+  showSummary,
   onImport,
   onExportSuite,
   onExportResults,
   onRunAll,
   onSave,
   onAddTestCase,
+  onToggleSummary,
 }) => {
   let fileInputRef: HTMLInputElement;
 
@@ -85,6 +89,17 @@ export const LLMTestRunnerHeader: FunctionalComponent<
         >
           {isExportingTestSuite ? 'Exporting…' : 'Export suite'}
         </Button>
+        <label class="test-runner-header__toggle">
+          <input
+            type="checkbox"
+            class="test-runner-header__toggle-input"
+            checked={showSummary}
+            onChange={(e) =>
+              onToggleSummary((e.target as HTMLInputElement).checked)
+            }
+          />
+          <span class="test-runner-header__toggle-label">Show summary</span>
+        </label>
       </div>
 
       <div class="test-runner-header__right">

--- a/src/components/llm-test-runner/header/llm-test-runner-header.tsx
+++ b/src/components/llm-test-runner/header/llm-test-runner-header.tsx
@@ -1,5 +1,15 @@
 import { h, FunctionalComponent } from '@stencil/core';
 import { Button } from '../../../lib/ui/button/index';
+import {
+  UploadIcon,
+  DownloadIcon,
+  FileTextIcon,
+  SaveIcon,
+  SlidersIcon,
+  PlayIcon,
+  SpinnerIcon,
+  PlusIcon,
+} from '../../../lib/ui/icons/icons';
 
 export interface LLMTestRunnerHeaderProps {
   isExportingTestSuite: boolean;
@@ -13,6 +23,7 @@ export interface LLMTestRunnerHeaderProps {
   onExportResults: () => void;
   onRunAll: () => void;
   onSave?: () => void;
+  onAddTestCase: () => void;
 }
 
 export const LLMTestRunnerHeader: FunctionalComponent<
@@ -29,6 +40,7 @@ export const LLMTestRunnerHeader: FunctionalComponent<
   onExportResults,
   onRunAll,
   onSave,
+  onAddTestCase,
 }) => {
   let fileInputRef: HTMLInputElement;
 
@@ -56,62 +68,71 @@ export const LLMTestRunnerHeader: FunctionalComponent<
           accept=".json,application/json"
         />
         <Button
-          variant="secondary"
+          variant="outline"
           size="md"
           onClick={handleFileSelect}
-          icon="↑"
+          icon={<UploadIcon />}
         >
-          Import Test Suite
+          Import suite
         </Button>
         <Button
-          variant="secondary"
+          variant="outline"
           size="md"
           onClick={onExportSuite}
           disabled={isExportingTestSuite}
           loading={isExportingTestSuite}
-          icon={isExportingTestSuite ? '⏳' : '↓'}
+          icon={isExportingTestSuite ? <SpinnerIcon /> : <DownloadIcon />}
         >
-          {isExportingTestSuite ? 'Exporting...' : 'Export Test Suite'}
+          {isExportingTestSuite ? 'Exporting…' : 'Export suite'}
         </Button>
       </div>
 
       <div class="test-runner-header__right">
         {usePromptEditor && (
-          <Button variant="secondary" size="md" icon="⚙️">
-            Prompt Editor
+          <Button variant="outline" size="md" icon={<SlidersIcon />}>
+            Prompt editor
           </Button>
         )}
         <Button
-          variant="secondary"
+          variant="outline"
+          size="md"
+          onClick={onAddTestCase}
+          icon={<PlusIcon />}
+        >
+          Add question
+        </Button>
+        <Button
+          variant="outline"
           size="md"
           onClick={onExportResults}
           disabled={isExportingTestResults}
           loading={isExportingTestResults}
-          icon={isExportingTestResults ? '⏳' : '↓'}
+          icon={isExportingTestResults ? <SpinnerIcon /> : <FileTextIcon />}
         >
-          {isExportingTestResults ? 'Exporting...' : 'Export Test Results'}
+          {isExportingTestResults ? 'Exporting…' : 'Export results'}
         </Button>
         {useSave && (
           <Button
-            variant="secondary"
+            variant="outline"
             size="md"
             onClick={onSave}
             disabled={isSaving}
             loading={isSaving}
-            icon={isSaving ? '⏳' : '💾'}
+            icon={isSaving ? <SpinnerIcon /> : <SaveIcon />}
           >
-            {isSaving ? 'Saving...' : 'Save'}
+            {isSaving ? 'Saving…' : 'Save'}
           </Button>
         )}
         <Button
-          aria-label="Run All"
+          aria-label="Run all"
           variant="primary"
           size="md"
           onClick={onRunAll}
           disabled={isRunningAll}
           loading={isRunningAll}
+          icon={isRunningAll ? <SpinnerIcon /> : <PlayIcon />}
         >
-          {isRunningAll ? 'Running...' : 'Run All'}
+          {isRunningAll ? 'Running…' : 'Run all'}
         </Button>
       </div>
     </header>

--- a/src/components/llm-test-runner/llm-test-runner.css
+++ b/src/components/llm-test-runner/llm-test-runner.css
@@ -1,10 +1,12 @@
 :host {
   display: block;
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
-    Cantarell, sans-serif;
-  background-color: var(--muted);
-  min-height: 100vh;
+  font-family: var(--font-family-sans);
+  font-feature-settings: 'cv11', 'ss01', 'ss03';
+  letter-spacing: var(--letter-spacing-snug);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background: var(--background);
+  color: var(--foreground);
 }
 
 /* CSS Reset for test-runner-container */
@@ -17,15 +19,19 @@
 }
 
 .test-runner-container {
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: var(--spacing-5);
+  /* Use full available width — the demo page provides outer breathing
+   * room via responsive padding on <body>. Eliminates the old 1400px cap
+   * that left big empty rails on wide displays. */
+  width: 100%;
+  margin: 0;
+  padding: 0;
   background: var(--background);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-lg);
+  border: var(--border-width) solid var(--border);
+  border-radius: var(--radius-xl);
+  overflow-x: clip;
+  min-height: 100%;
 }
 
-/* Container Element: Content */
 .test-runner-container__content {
   padding: 0;
 }

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -43,6 +43,7 @@ import {
   validateExpectedOutcomeSchema,
 } from '../../schemas/expected-outcome';
 import { LLMTestRunnerHeader } from './header/llm-test-runner-header';
+import { LLMTestRunnerSummary } from './summary/llm-test-runner-summary';
 import { LLMTestCases } from './test-cases/llm-test-cases';
 import { ExpectedOutcomeChangeDetail } from './test-cases/expected-outcome-renderer';
 import type { ChatHistoryRowChangeDetail } from './test-cases/llm-test-case-row';
@@ -60,6 +61,7 @@ function nextFrame(): Promise<void> {
     '../../styles/tokens.css',
     'llm-test-runner.css',
     'header/llm-test-runner-header.css',
+    'summary/llm-test-runner-summary.css',
     'test-cases/llm-test-cases.css',
     'test-cases/llm-test-case-row.css',
     'test-cases/actions/row-actions.css',
@@ -103,6 +105,7 @@ export class LLMTestRunner {
   @State() isExportingTestSuite: boolean = false;
   @State() isExportingTestResults: boolean = false;
   @State() isSaving: boolean = false;
+  @State() showSummary: boolean = true;
 
   private evaluationService: EvaluationService;
 
@@ -458,13 +461,18 @@ export class LLMTestRunner {
           useSave={this.useSave}
           isSaving={this.isSaving}
           usePromptEditor={this.usePromptEditor}
+          showSummary={this.showSummary}
           onImport={file => this.handleImport(file)}
           onExportSuite={() => this.handleExportTestSuite()}
           onExportResults={() => this.handleExportTestResults()}
           onRunAll={() => this.runAllTests()}
           onSave={() => this.handleSave()}
           onAddTestCase={() => this.addNewTestCase()}
+          onToggleSummary={(show) => (this.showSummary = show)}
         />
+        {this.showSummary && (
+          <LLMTestRunnerSummary testCases={this.testCases} />
+        )}
         <ErrorMessage message={this.error} onClear={() => (this.error = '')} />
         <div class="test-runner-container__content">
           <LLMTestCases

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -6,6 +6,7 @@ import {
   EventEmitter,
   Event,
   Method,
+  Element,
 } from '@stencil/core';
 import { EvaluationResult } from '../../lib/evaluation/types';
 import { ErrorMessage } from '../error-message/error-message';
@@ -46,6 +47,13 @@ import { LLMTestCases } from './test-cases/llm-test-cases';
 import { ExpectedOutcomeChangeDetail } from './test-cases/expected-outcome-renderer';
 import type { ChatHistoryRowChangeDetail } from './test-cases/llm-test-case-row';
 
+const HIGHLIGHT_VISIBLE_MS = 2000;
+const ELEMENT_LOOKUP_MAX_FRAMES = 10;
+
+function nextFrame(): Promise<void> {
+  return new Promise(resolve => requestAnimationFrame(() => resolve()));
+}
+
 @Component({
   tag: 'llm-test-runner',
   styleUrls: [
@@ -66,6 +74,7 @@ import type { ChatHistoryRowChangeDetail } from './test-cases/llm-test-case-row'
 export class LLMTestRunner {
   @Event() llmRequest: EventEmitter<LLMRequestPayload>;
   @Event() save: EventEmitter<SavePayload>;
+  @Element() el: HTMLElement;
   @Prop() delayMs?: number = 500;
   @Prop() useSave?: boolean = false;
   @Prop() usePromptEditor?: boolean = false;
@@ -175,12 +184,44 @@ export class LLMTestRunner {
       const schema = this.getResolvedExpectedOutcomeSchema();
       const newTestCase = createTestCase(schema);
       this.testCases = [...this.testCases, newTestCase];
+
+      // Fire-and-forget: scroll runs after the next render completes.
+      void this.scrollToAndHighlightTestCase(newTestCase.id);
     } catch (err) {
       this.error =
         err instanceof Error
           ? err.message
           : 'Invalid defaultExpectedOutcomeSchema provided.';
     }
+  }
+
+  private async scrollToAndHighlightTestCase(testCaseId: string): Promise<void> {
+    const element = await this.waitForTestCaseElement(testCaseId);
+    if (!element) return;
+
+    (element as HTMLDetailsElement).open = true;
+    await nextFrame();
+
+    element.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+      inline: 'nearest',
+    });
+    element.classList.add('test-case-row--highlight');
+
+    window.setTimeout(() => {
+      element.classList.remove('test-case-row--highlight');
+    }, HIGHLIGHT_VISIBLE_MS);
+  }
+
+  private async waitForTestCaseElement(testCaseId: string): Promise<Element | null> {
+    const selector = `.test-case-row[data-test-case-id="${CSS.escape(testCaseId)}"]`;
+    for (let i = 0; i < ELEMENT_LOOKUP_MAX_FRAMES; i++) {
+      const element = this.el.shadowRoot?.querySelector(selector);
+      if (element) return element;
+      await nextFrame();
+    }
+    return null;
   }
 
   private updateTestCase(id: string, updates: Partial<TestCase>) {
@@ -422,6 +463,7 @@ export class LLMTestRunner {
           onExportResults={() => this.handleExportTestResults()}
           onRunAll={() => this.runAllTests()}
           onSave={() => this.handleSave()}
+          onAddTestCase={() => this.addNewTestCase()}
         />
         <ErrorMessage message={this.error} onClear={() => (this.error = '')} />
         <div class="test-runner-container__content">
@@ -431,7 +473,6 @@ export class LLMTestRunner {
             extractorIds={getExtractorIds(this.evaluationSourceExtractors)}
             onRun={testCase => this.runSingleTest(testCase).catch(() => {})}
             onDelete={id => this.deleteTestCase(id)}
-            onAddTestCase={() => this.addNewTestCase()}
             handleTestCaseChange={this.handleTestCaseChange}
             onExpectedOutcomeChange={this.handleExpectedOutcomeChange}
             onChatHistoryChange={this.handleChatHistoryChange}

--- a/src/components/llm-test-runner/summary/llm-test-runner-summary.css
+++ b/src/components/llm-test-runner/summary/llm-test-runner-summary.css
@@ -1,0 +1,148 @@
+/* ------------------------------------------------------------------ */
+/* Summary bar — sits directly beneath the top header as an extension. */
+/* ------------------------------------------------------------------ */
+
+.test-runner-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-6);
+  padding: var(--spacing-3) var(--spacing-5);
+  background: var(--background);
+  color: var(--foreground);
+  border-bottom: var(--border-width) solid var(--border);
+  position: sticky;
+  /* Sits just below the main header (which is also sticky at top:0). The
+   * header is ~57px tall on default sizing; using a calc keeps us tied to
+   * the header padding/line-height tokens so it stays accurate. */
+  top: var(--summary-bar-offset, 57px);
+  z-index: calc(var(--z-sticky) - 1);
+}
+
+/* Pass-rate cluster — large numeric reading on the far left. */
+.test-runner-summary__rate {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-2);
+}
+
+.test-runner-summary__rate-value {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--letter-spacing-tight);
+  color: var(--foreground);
+  line-height: var(--line-height-none);
+}
+
+.test-runner-summary__rate-label {
+  font-size: var(--font-size-sm);
+  color: var(--muted-foreground);
+}
+
+/* Status chips */
+.test-runner-summary__chips {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.test-runner-summary__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  border: var(--border-width) solid transparent;
+  white-space: nowrap;
+}
+
+.test-runner-summary__chip::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.test-runner-summary__chip--passed {
+  background: var(--success-soft-bg);
+  color: var(--success-soft-fg);
+  border-color: var(--success-soft-border);
+}
+
+.test-runner-summary__chip--failed {
+  background: var(--destructive-soft-bg);
+  color: var(--destructive-soft-fg);
+  border-color: var(--destructive-soft-border);
+}
+
+.test-runner-summary__chip--not-run {
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border-color: var(--border);
+}
+
+/* Trailing total — quiet, sits to the right of the chips. */
+.test-runner-summary__total {
+  font-size: var(--font-size-sm);
+  color: var(--muted-foreground);
+  margin-left: auto;
+}
+
+/* ------------------------------------------------------------------ */
+/* Number transitions                                                  */
+/* Each numeric span is re-keyed when its value changes, which causes  */
+/* Stencil to swap the node and re-run the entrance animation. Subtle  */
+/* pop + fade so changes feel "live" without being distracting.        */
+/* ------------------------------------------------------------------ */
+.test-runner-summary__rate-value,
+.test-runner-summary__chip-count,
+.test-runner-summary__total-count {
+  display: inline-block;
+  transform-origin: center;
+  animation: test-runner-summary-number-pop 320ms
+    cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.test-runner-summary__rate-value {
+  /* Slightly slower + larger overshoot for the headline number. */
+  animation-duration: 420ms;
+}
+
+@keyframes test-runner-summary-number-pop {
+  0% {
+    transform: scale(0.7) translateY(3px);
+    opacity: 0;
+  }
+  55% {
+    transform: scale(1.12) translateY(0);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .test-runner-summary__rate-value,
+  .test-runner-summary__chip-count,
+  .test-runner-summary__total-count {
+    animation: none;
+  }
+}
+
+/* Responsive */
+@media (max-width: 768px) /* var(--breakpoint-md) */ {
+  .test-runner-summary {
+    flex-wrap: wrap;
+    gap: var(--spacing-3);
+    padding: var(--spacing-3) var(--spacing-4);
+  }
+
+  .test-runner-summary__total {
+    margin-left: 0;
+  }
+}

--- a/src/components/llm-test-runner/summary/llm-test-runner-summary.tsx
+++ b/src/components/llm-test-runner/summary/llm-test-runner-summary.tsx
@@ -1,0 +1,94 @@
+import { h, FunctionalComponent } from '@stencil/core';
+import { TestCase } from '../../../types/llm-test-runner';
+import { computeTestStatus } from '../test-cases/llm-test-case-row';
+
+export interface SummaryStats {
+  total: number;
+  passed: number;
+  failed: number;
+  notRun: number;
+  passRate: number;
+}
+
+/**
+ * Aggregate per-test statuses into summary counts.
+ *
+ * Buckets:
+ *  - passed  → fully passed
+ *  - failed  → has results but didn't fully pass (includes 'partial')
+ *  - notRun  → no completed evaluation yet (includes currently running)
+ *
+ * passRate is passed / total, rounded to nearest integer.
+ */
+export function computeSummaryStats(testCases: TestCase[]): SummaryStats {
+  const total = testCases.length;
+  let passed = 0;
+  let failed = 0;
+  let notRun = 0;
+
+  for (const tc of testCases) {
+    const { kind } = computeTestStatus(tc);
+    if (kind === 'passed') {
+      passed += 1;
+    } else if (kind === 'failed' || kind === 'partial') {
+      failed += 1;
+    } else {
+      // 'not-run' | 'running' | 'evaluating'
+      notRun += 1;
+    }
+  }
+
+  const passRate = total > 0 ? Math.round((passed / total) * 100) : 0;
+  return { total, passed, failed, notRun, passRate };
+}
+
+export interface LLMTestRunnerSummaryProps {
+  testCases: TestCase[];
+}
+
+export const LLMTestRunnerSummary: FunctionalComponent<
+  LLMTestRunnerSummaryProps
+> = ({ testCases }) => {
+  const { total, passed, failed, notRun, passRate } =
+    computeSummaryStats(testCases);
+  const testNoun = total === 1 ? 'test' : 'tests';
+
+  return (
+    <div class="test-runner-summary" role="status" aria-label="Test suite summary">
+      <div class="test-runner-summary__rate">
+        <span class="test-runner-summary__rate-value" key={`rate-${passRate}`}>
+          {passRate}%
+        </span>
+        <span class="test-runner-summary__rate-label">pass rate</span>
+      </div>
+
+      <div class="test-runner-summary__chips">
+        <span class="test-runner-summary__chip test-runner-summary__chip--passed">
+          <span class="test-runner-summary__chip-count" key={`passed-${passed}`}>
+            {passed}
+          </span>{' '}
+          passed
+        </span>
+        <span class="test-runner-summary__chip test-runner-summary__chip--failed">
+          <span class="test-runner-summary__chip-count" key={`failed-${failed}`}>
+            {failed}
+          </span>{' '}
+          failed
+        </span>
+        <span class="test-runner-summary__chip test-runner-summary__chip--not-run">
+          <span class="test-runner-summary__chip-count" key={`notrun-${notRun}`}>
+            {notRun}
+          </span>{' '}
+          not run
+        </span>
+      </div>
+
+      <div class="test-runner-summary__total">
+        <span class="test-runner-summary__total-count" key={`total-${total}`}>
+          {total}
+        </span>{' '}
+        {testNoun}
+      </div>
+    </div>
+  );
+};

--- a/src/components/llm-test-runner/test-cases/actions/row-actions.tsx
+++ b/src/components/llm-test-runner/test-cases/actions/row-actions.tsx
@@ -1,5 +1,10 @@
 import { h, FunctionalComponent } from '@stencil/core';
 import { IconButton } from '../../../../lib/ui/icon-button/index';
+import {
+  PlayIcon,
+  SpinnerIcon,
+  TrashIcon,
+} from '../../../../lib/ui/icons/icons';
 
 export interface RowActionsProps {
   isRunning: boolean;
@@ -17,15 +22,19 @@ export const RowActions: FunctionalComponent<RowActionsProps> = ({
   return (
     <div class="row-actions">
       <IconButton
-        variant="outline"
+        variant="primary"
         onClick={onRun}
         disabled={isRunning || !canRun}
         title={!canRun ? 'Enter a question first' : 'Run this test'}
       >
-        {isRunning ? '⏳' : '▶️'}
+        {isRunning ? <SpinnerIcon /> : <PlayIcon />}
       </IconButton>
-      <IconButton variant="outline" onClick={onDelete} title="Delete this test">
-        🗑️
+      <IconButton
+        variant="outline"
+        onClick={onDelete}
+        title="Delete this test"
+      >
+        <TrashIcon />
       </IconButton>
     </div>
   );

--- a/src/components/llm-test-runner/test-cases/chat-history.css
+++ b/src/components/llm-test-runner/test-cases/chat-history.css
@@ -1,101 +1,112 @@
+:host {
+  display: block;
+}
+
+/*
+ * Chat history is now a disclosure (<details>) — the same pattern as the
+ * "More options" panel in the field renderer, so the row has consistent
+ * affordances for optional content. Collapsed = enabled false, expanded =
+ * enabled true. The textarea value is preserved across collapses so the
+ * user can hide it without losing their input.
+ */
 .chat-history {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-3);
-  margin-top: var(--spacing-4);
-}
-
-.chat-history__toggle-row {
-  display: flex;
-  align-items: center;
-}
-
-.chat-history__switch {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-3);
-  cursor: pointer;
-  user-select: none;
-}
-
-.chat-history__switch-input {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.chat-history__switch-ui {
-  position: relative;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  padding: 0px 4px;
-  width: 2.75rem;
-  height: 1.5rem;
-  border-radius: var(--radius-full);
-  background: var(--muted);
   border: var(--border-width) solid var(--border);
-  transition:
-    background 0.15s ease,
-    border-color 0.15s ease;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .chat-history__switch-ui,
-  .chat-history__switch-thumb {
-    transition: none;
-  }
-}
-
-.chat-history__switch-thumb {
-  display: inline-block;
-  width: calc(1.5rem - 6px);
-  height: calc(1.5rem - 6px);
-  border-radius: var(--radius-full);
+  border-radius: var(--radius-lg);
   background: var(--background);
-  box-shadow: var(--shadow-sm);
-  transition: transform 0.15s ease;
+  overflow: hidden;
+  transition: border-color 150ms ease;
 }
 
-.chat-history__switch-input:checked + .chat-history__switch-ui {
-  background: var(--primary);
-  border-color: var(--primary);
+.chat-history[open] {
+  border-color: var(--border-strong);
 }
 
-.chat-history__switch-input:checked + .chat-history__switch-ui .chat-history__switch-thumb {
-  transform: translateX(calc(2.75rem - (1.5rem - 6px)));
+.chat-history:focus-within {
+  border-color: var(--border-strong);
 }
 
-.chat-history__switch-input:focus-visible + .chat-history__switch-ui {
-  outline: 2px solid var(--ring);
-  outline-offset: 2px;
+.chat-history__summary {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wider);
+  color: var(--muted-foreground);
+  user-select: none;
+  list-style: none;
+  background: transparent;
+  transition: color 150ms ease, background-color 150ms ease;
 }
 
-.chat-history__switch-text {
-  font-size: var(--font-size-sm, 0.875rem);
+.chat-history__summary:hover {
   color: var(--foreground);
+  background: var(--muted);
+}
+
+.chat-history[open] .chat-history__summary {
+  color: var(--foreground);
+  border-bottom: var(--border-width) solid var(--border);
+  background: var(--muted);
+}
+
+/* Hide native disclosure markers — we draw a custom chevron via ::before. */
+.chat-history__summary::-webkit-details-marker {
+  display: none;
+}
+
+.chat-history__summary::marker {
+  display: none;
+  content: '';
+}
+
+/* Custom chevron — rotates 90° on open, matching the More options panel. */
+.chat-history__summary::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor;
+  transition: transform 200ms ease;
+  transform-origin: 25% 50%;
+  flex-shrink: 0;
+}
+
+.chat-history[open] .chat-history__summary::before {
+  transform: rotate(90deg);
+}
+
+.chat-history__icon {
+  flex-shrink: 0;
+  /* Slight muting so the icon doesn't compete with the chevron. */
+  opacity: 0.7;
+}
+
+.chat-history__label {
+  /* Span is stylistic — letter-spacing already comes from the summary. */
+}
+
+.chat-history__content {
+  padding: 0;
+  background: var(--background);
 }
 
 .chat-history__textarea {
   width: 100%;
   box-sizing: border-box;
   padding: var(--spacing-2) var(--spacing-3);
-  border: var(--border-width) solid var(--border);
-  border-radius: var(--radius-md);
-  font: inherit;
+  border: none;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.55;
   resize: vertical;
-  min-height: 9rem;
+  min-height: 8rem;
   background: var(--background);
-}
-
-.chat-history__textarea:focus-visible {
-  outline: 2px solid var(--ring);
-  outline-offset: 2px;
+  color: var(--foreground);
+  outline: none;
 }

--- a/src/components/llm-test-runner/test-cases/chat-history.spec.tsx
+++ b/src/components/llm-test-runner/test-cases/chat-history.spec.tsx
@@ -19,12 +19,18 @@ function attachControlledParent(page: SpecPage): void {
   });
 }
 
-async function enableChatHistoryAsUser(page: SpecPage): Promise<void> {
+/**
+ * Native <details> doesn't fire `toggle` from a programmatic `.open = ...`
+ * change in jsdom; we trigger it explicitly so the component's onToggle
+ * handler observes the new state, just as it would in a real browser.
+ */
+async function openChatHistoryAsUser(page: SpecPage): Promise<void> {
   attachControlledParent(page);
-  const toggle = page.root.shadowRoot!.querySelector(
-    '.chat-history__switch-input',
-  ) as HTMLInputElement;
-  setCheckboxChecked(toggle, true);
+  const details = page.root.shadowRoot!.querySelector(
+    'details',
+  ) as HTMLDetailsElement;
+  details.open = true;
+  details.dispatchEvent(new Event('toggle', { bubbles: true }));
   await page.waitForChanges();
 }
 
@@ -36,9 +42,12 @@ function getTextareaValue(textarea: HTMLTextAreaElement): string {
   return textarea.getAttribute('value') ?? '';
 }
 
-function setCheckboxChecked(input: HTMLInputElement, checked: boolean): void {
-  input.checked = checked;
-  input.dispatchEvent(new Event('input', { bubbles: true }));
+// Stencil's spec DOM doesn't reflect the `open` property on <details> the
+// way real browsers do. Read the attribute (set by the JSX `open={...}`
+// binding) instead.
+function isDetailsOpen(details: HTMLDetailsElement): boolean {
+  if (typeof details.open === 'boolean') return details.open;
+  return details.hasAttribute('open');
 }
 
 describe('ChatHistory', () => {
@@ -46,7 +55,7 @@ describe('ChatHistory', () => {
     jest.clearAllMocks();
   });
 
-  it('shows toggle on and textarea value from props', async () => {
+  it('renders open with textarea value from props when enabled', async () => {
     const page = await newSpecPage({
       components: [ChatHistory],
       html: '<chat-history chat-history-enabled chat-history-value="[imported]"></chat-history>',
@@ -54,58 +63,60 @@ describe('ChatHistory', () => {
 
     await page.waitForChanges();
 
+    const details = page.root.shadowRoot.querySelector(
+      'details',
+    ) as HTMLDetailsElement;
+    expect(isDetailsOpen(details)).toBe(true);
+
     const textarea = page.root.shadowRoot.querySelector(
       '.chat-history__textarea',
     ) as HTMLTextAreaElement;
     expect(textarea).not.toBeNull();
     expect(getTextareaValue(textarea)).toBe('[imported]');
-    const toggle = page.root.shadowRoot.querySelector(
-      '.chat-history__switch-input',
-    ) as HTMLInputElement;
-    expect(toggle.checked).toBe(true);
   });
 
-  it('does not render the textarea when disabled', async () => {
+  it('renders collapsed (open=false) by default', async () => {
     const page = await newSpecPage({
       components: [ChatHistory],
       html: '<chat-history></chat-history>',
     });
 
-    expect(page.root.shadowRoot.querySelector('.chat-history__textarea')).toBeNull();
+    const details = page.root.shadowRoot.querySelector(
+      'details',
+    ) as HTMLDetailsElement;
+    expect(isDetailsOpen(details)).toBe(false);
   });
 
-  it('renders the textarea only after the parent sets enabled (user toggle + prop sync)', async () => {
+  it('shows the summary label and chat icon at all times', async () => {
     const page = await newSpecPage({
       components: [ChatHistory],
       html: '<chat-history></chat-history>',
     });
 
-    await enableChatHistoryAsUser(page);
+    const summary = page.root.shadowRoot.querySelector(
+      '.chat-history__summary',
+    );
+    expect(summary).not.toBeNull();
+    expect(summary?.textContent).toContain('Chat history');
+    expect(
+      page.root.shadowRoot.querySelector('.chat-history__icon'),
+    ).not.toBeNull();
+  });
+
+  it('opens to reveal the textarea after the user expands the disclosure', async () => {
+    const page = await newSpecPage({
+      components: [ChatHistory],
+      html: '<chat-history></chat-history>',
+    });
+
+    await openChatHistoryAsUser(page);
 
     expect(
       page.root.shadowRoot.querySelector('.chat-history__textarea'),
     ).not.toBeNull();
   });
 
-  it('keeps typed value in the textarea while enabled', async () => {
-    const page = await newSpecPage({
-      components: [ChatHistory],
-      html: '<chat-history></chat-history>',
-    });
-
-    await enableChatHistoryAsUser(page);
-
-    const textarea = page.root.shadowRoot.querySelector(
-      '.chat-history__textarea',
-    ) as HTMLTextAreaElement;
-    textarea.value = 'paste-json-here';
-    textarea.dispatchEvent(new Event('input', { bubbles: true }));
-    await page.waitForChanges();
-
-    expect(getTextareaValue(textarea)).toBe('paste-json-here');
-  });
-
-  it('emits chatHistoryChange when the switch is toggled on', async () => {
+  it('emits chatHistoryChange with enabled=true when the user expands', async () => {
     const page = await newSpecPage({
       components: [ChatHistory],
       html: '<chat-history></chat-history>',
@@ -116,10 +127,11 @@ describe('ChatHistory', () => {
       spy((e as CustomEvent<ChatHistoryChangeDetail>).detail),
     );
 
-    const input = page.root.shadowRoot.querySelector(
-      '.chat-history__switch-input',
-    ) as HTMLInputElement;
-    setCheckboxChecked(input, true);
+    const details = page.root.shadowRoot.querySelector(
+      'details',
+    ) as HTMLDetailsElement;
+    details.open = true;
+    details.dispatchEvent(new Event('toggle', { bubbles: true }));
     await page.waitForChanges();
 
     expect(spy).toHaveBeenCalledWith({ enabled: true, value: '' });
@@ -131,7 +143,7 @@ describe('ChatHistory', () => {
       html: '<chat-history></chat-history>',
     });
 
-    await enableChatHistoryAsUser(page);
+    await openChatHistoryAsUser(page);
 
     const spy = jest.fn();
     page.root.addEventListener('chatHistoryChange', (e: Event) =>
@@ -149,22 +161,18 @@ describe('ChatHistory', () => {
     expect(spy).toHaveBeenCalledWith({ enabled: true, value: 'hello' });
   });
 
-  it('hides the textarea after toggling off and emits disabled state', async () => {
+  it('preserves typed value across collapse/expand toggles', async () => {
     const page = await newSpecPage({
       components: [ChatHistory],
       html: '<chat-history></chat-history>',
     });
 
-    await enableChatHistoryAsUser(page);
-
-    const toggle = page.root.shadowRoot.querySelector(
-      '.chat-history__switch-input',
-    ) as HTMLInputElement;
+    await openChatHistoryAsUser(page);
 
     const textarea = page.root.shadowRoot.querySelector(
       '.chat-history__textarea',
     ) as HTMLTextAreaElement;
-    textarea.value = 'keep';
+    textarea.value = 'keep me';
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
     await page.waitForChanges();
 
@@ -172,12 +180,15 @@ describe('ChatHistory', () => {
     page.root.addEventListener('chatHistoryChange', (e: Event) =>
       spy((e as CustomEvent<ChatHistoryChangeDetail>).detail),
     );
-    spy.mockClear();
 
-    setCheckboxChecked(toggle, false);
+    // User collapses — emit enabled=false but value is preserved.
+    const details = page.root.shadowRoot.querySelector(
+      'details',
+    ) as HTMLDetailsElement;
+    details.open = false;
+    details.dispatchEvent(new Event('toggle', { bubbles: true }));
     await page.waitForChanges();
 
-    expect(page.root.shadowRoot.querySelector('.chat-history__textarea')).toBeNull();
-    expect(spy).toHaveBeenCalledWith({ enabled: false, value: 'keep' });
+    expect(spy).toHaveBeenCalledWith({ enabled: false, value: 'keep me' });
   });
 });

--- a/src/components/llm-test-runner/test-cases/chat-history.tsx
+++ b/src/components/llm-test-runner/test-cases/chat-history.tsx
@@ -26,9 +26,18 @@ export class ChatHistory {
     this.chatHistoryChange.emit(detail);
   }
 
+  /**
+   * Native <details> fires `toggle` whenever its open state changes — both
+   * via user click on the summary AND from programmatic / prop-driven sync.
+   * We treat "open" as the source of truth for `enabled` and preserve the
+   * textarea value across collapses, so the user can quickly hide chat
+   * history without losing what they typed.
+   */
   private onToggle = (e: Event) => {
-    const checked = (e.target as HTMLInputElement).checked;
-    this.emit({ enabled: checked, value: this.chatHistoryValue });
+    const open = (e.target as HTMLDetailsElement).open;
+    if (open !== this.chatHistoryEnabled) {
+      this.emit({ enabled: open, value: this.chatHistoryValue });
+    }
   };
 
   private onTextInput = (e: Event) => {
@@ -38,32 +47,39 @@ export class ChatHistory {
 
   render() {
     return (
-      <div class="chat-history">
-        <div class="chat-history__toggle-row">
-          <label class="chat-history__switch">
-            <input
-              type="checkbox"
-              class="chat-history__switch-input"
-              checked={this.chatHistoryEnabled}
-              onInput={this.onToggle}
-            />
-            <span class="chat-history__switch-ui" aria-hidden="true">
-              <span class="chat-history__switch-thumb" />
-            </span>
-            <span class="chat-history__switch-text">Chat history</span>
-          </label>
-        </div>
-        {this.chatHistoryEnabled ? (
+      <details
+        class="chat-history"
+        open={this.chatHistoryEnabled}
+        onToggle={this.onToggle}
+      >
+        <summary class="chat-history__summary">
+          <svg
+            class="chat-history__icon"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+          </svg>
+          <span class="chat-history__label">Chat history</span>
+        </summary>
+        <div class="chat-history__content">
           <textarea
             class="chat-history__textarea"
             value={this.chatHistoryValue}
-            rows={8}
+            rows={6}
             placeholder={CHAT_HISTORY_PLACEHOLDER}
             aria-label="Chat history"
             onInput={this.onTextInput}
           />
-        ) : null}
-      </div>
+        </div>
+      </details>
     );
   }
 }

--- a/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.css
+++ b/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.css
@@ -1,10 +1,10 @@
 /* Evaluation Summary Block */
 .evaluation-summary {
-  padding: var(--spacing-5);
+  padding: var(--spacing-4);
   background: var(--background);
-  border-right: var(--border-width) solid var(--border);
   display: flex;
   flex-direction: column;
+  flex: 1;
 }
 
 .evaluation-summary__field-results {
@@ -46,25 +46,40 @@
   font-size: var(--font-size-xs);
 }
 
+/* Soft chip-style status badge — dot + label, calm rather than alarming.
+ * Inspired by Linear / Vercel / GitHub. */
 .evaluation-summary__field-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   width: fit-content;
-  padding: 2px var(--spacing-2);
-  border-radius: var(--radius-sm);
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
   font-size: 11px;
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-snug);
   border: var(--border-width) solid transparent;
 }
 
+.evaluation-summary__field-status::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
 .evaluation-summary__field-status--passed {
-  background: var(--success);
-  color: var(--success-foreground);
-  border-color: var(--success);
+  background: var(--success-soft-bg);
+  color: var(--success-soft-fg);
+  border-color: var(--success-soft-border);
 }
 
 .evaluation-summary__field-status--failed {
-  background: var(--destructive);
-  color: var(--destructive-foreground);
-  border-color: var(--destructive);
+  background: var(--destructive-soft-bg);
+  color: var(--destructive-soft-fg);
+  border-color: var(--destructive-soft-border);
 }
 
 .evaluation-summary__error-message {
@@ -73,25 +88,121 @@
 }
 
 .evaluation-summary__warning-message {
-  color: var(--warning);
+  color: var(--warning-soft-fg);
   font-size: var(--font-size-xs);
-  background: rgba(245, 158, 11, 0.08);
-  border-left: 2px solid var(--warning);
-  padding: var(--spacing-1) var(--spacing-2);
-  border-radius: var(--radius-sm);
-  line-height: 1.3;
+  background: var(--warning-soft-bg);
+  border: var(--border-width) solid var(--warning-soft-border);
+  padding: 6px 10px;
+  border-radius: var(--radius-md);
+  line-height: 1.4;
 }
 
 .evaluation-summary__placeholder {
   display: flex;
   align-items: center;
   justify-content: center;
+  text-align: center;
   color: var(--muted-foreground);
-  font-style: italic;
+  font-size: var(--font-size-sm);
   flex: 1;
+  padding: var(--spacing-4);
   background: var(--muted);
-  border: 2px dashed var(--border);
   border-radius: var(--radius);
+}
+
+.evaluation-summary__skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0;
+}
+
+/* A pill-shaped skeleton sized like the Pass/Fail status badge. */
+.evaluation-summary__skeleton-pill {
+  width: 80px;
+  height: 22px;
+  border-radius: var(--radius-full);
+  background:
+    linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.06) 0%,
+      rgba(0, 0, 0, 0.12) 50%,
+      rgba(0, 0, 0, 0.06) 100%
+    );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+/* Per-criterion rows — id-line on the left, score on the right. */
+.evaluation-summary__skeleton-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-top: 4px;
+}
+
+.evaluation-summary__skeleton-score {
+  width: 32px;
+  height: 12px;
+  border-radius: var(--radius-full);
+  background:
+    linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.06) 0%,
+      rgba(0, 0, 0, 0.12) 50%,
+      rgba(0, 0, 0, 0.06) 100%
+    );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+/* Shared shimmer helper — local to this shadow root. */
+.skeleton-line {
+  height: 12px;
+  border-radius: var(--radius-full);
+  background:
+    linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.06) 0%,
+      rgba(0, 0, 0, 0.12) 50%,
+      rgba(0, 0, 0, 0.06) 100%
+    );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+.skeleton-line--w-60 { width: 60%; }
+.skeleton-line--w-50 { width: 50%; }
+.skeleton-line--w-40 { width: 40%; }
+
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .evaluation-summary__skeleton-pill,
+  .evaluation-summary__skeleton-score,
+  .skeleton-line {
+    animation: none;
+    opacity: 0.7;
+  }
+}
+
+.evaluation-summary__criterion-results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  margin-top: var(--spacing-1);
+}
+
+.evaluation-summary__criterion-results-label {
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--muted-foreground);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .evaluation-summary__criterion-list {
@@ -100,7 +211,7 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
 
 /* Grid layout (1fr | auto) so the id column can shrink when it's long,
@@ -116,29 +227,19 @@
 }
 
 .evaluation-summary__criterion-id {
-  font-family: var(--font-family-mono, ui-monospace, "SF Mono", Menlo, monospace);
+  font-family: var(--font-family-mono);
+  font-size: 12px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
+  color: var(--foreground);
 }
 
 .evaluation-summary__criterion-score {
-  font-variant-numeric: tabular-nums;
   text-align: right;
-}
-
-.evaluation-summary__placeholder--running {
-  animation: placeholder-pulse 1.6s ease-in-out infinite;
-}
-
-.evaluation-summary__placeholder-text::after {
-  content: '...';
-  display: inline-block;
-  width: 0;
-  overflow: hidden;
-  vertical-align: bottom;
-  animation: placeholder-dots 1.4s steps(4) infinite;
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--font-weight-medium);
 }
 
 /* Evaluation Result Element */
@@ -149,15 +250,8 @@
 }
 
 /* Responsive Design */
-@media (max-width: 1200px) {
-  .evaluation-summary {
-    border-right: none;
-    border-bottom: var(--border-width) solid var(--border);
-  }
-}
-
 @media (max-width: 768px) {
   .evaluation-summary {
-    padding: var(--spacing-4);
+    padding: var(--spacing-3);
   }
 }

--- a/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.tsx
+++ b/src/components/llm-test-runner/test-cases/evaluation/evaluation-summary.tsx
@@ -12,6 +12,35 @@ export const EvaluationSummary: FunctionalComponent<EvaluationSummaryProps> = ({
 }) => {
   const fieldResults = result?.fieldResults || [];
   const hasFieldResults = fieldResults.length > 0;
+  // Skeleton shows while a run is in progress and no result has landed
+  // yet. Mimics the eventual layout: status pill + score line + a couple
+  // of criterion rows. Reads as "evaluation is being computed" rather
+  // than dead-air "Evaluating…" copy.
+  const showSkeleton = isRunning && !result;
+
+  if (showSkeleton) {
+    return (
+      <div
+        class="evaluation-summary"
+        aria-busy="true"
+        aria-label="Evaluating response"
+      >
+        <div class="evaluation-summary__skeleton">
+          <div class="evaluation-summary__skeleton-pill"></div>
+          <div class="skeleton-line skeleton-line--w-60"></div>
+          <div class="skeleton-line skeleton-line--w-40"></div>
+          <div class="evaluation-summary__skeleton-row">
+            <div class="skeleton-line skeleton-line--w-50"></div>
+            <div class="evaluation-summary__skeleton-score"></div>
+          </div>
+          <div class="evaluation-summary__skeleton-row">
+            <div class="skeleton-line skeleton-line--w-40"></div>
+            <div class="evaluation-summary__skeleton-score"></div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div class="evaluation-summary">
@@ -33,7 +62,7 @@ export const EvaluationSummary: FunctionalComponent<EvaluationSummaryProps> = ({
                     <span
                       class={`evaluation-summary__field-status evaluation-summary__field-status--${fieldResult.passed ? 'passed' : 'failed'}`}
                     >
-                      {fieldResult.passed ? 'PASSED' : 'FAILED'}
+                      {fieldResult.passed ? 'Passed' : 'Failed'}
                     </span>
                     {fieldResult.error && (
                       <span class="evaluation-summary__error-message">
@@ -58,21 +87,26 @@ export const EvaluationSummary: FunctionalComponent<EvaluationSummaryProps> = ({
                     </span>
                     {fieldResult.criterionResults &&
                       fieldResult.criterionResults.length > 0 && (
-                        <ul class="evaluation-summary__criterion-list">
-                          {fieldResult.criterionResults.map(criterion => (
-                            <li class="evaluation-summary__criterion-item">
-                              <span
-                                class="evaluation-summary__criterion-id"
-                                title={criterion.id}
-                              >
-                                {criterion.id}
-                              </span>
-                              <span class="evaluation-summary__criterion-score">
-                                {criterion.score.toFixed(2)}
-                              </span>
-                            </li>
-                          ))}
-                        </ul>
+                        <div class="evaluation-summary__criterion-results">
+                          <span class="evaluation-summary__criterion-results-label">
+                            Criteria
+                          </span>
+                          <ul class="evaluation-summary__criterion-list">
+                            {fieldResult.criterionResults.map(criterion => (
+                              <li class="evaluation-summary__criterion-item">
+                                <span
+                                  class="evaluation-summary__criterion-id"
+                                  title={criterion.id}
+                                >
+                                  {criterion.id}
+                                </span>
+                                <span class="evaluation-summary__criterion-score">
+                                  {criterion.score.toFixed(2)}
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
                       )}
                   </div>
                 </div>
@@ -81,15 +115,8 @@ export const EvaluationSummary: FunctionalComponent<EvaluationSummaryProps> = ({
           ) : null}
         </div>
       ) : (
-        <div
-          class={{
-            'evaluation-summary__placeholder': true,
-            'evaluation-summary__placeholder--running': isRunning,
-          }}
-        >
-          {isRunning && (
-            <span class="evaluation-summary__placeholder-text">Evaluating</span>
-          )}
+        <div class="evaluation-summary__placeholder">
+          Run the test to see the evaluation result.
         </div>
       )}
     </div>

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.css
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.css
@@ -1,37 +1,286 @@
-/* Test Case Row Block */
-.test-case-row {
-  display: grid;
-  grid-template-columns: 1fr 1.5fr 0.5fr 120px;
-  gap: var(--border-width);
-  border-bottom: var(--border-width) solid var(--border);
-  min-height: 200px;
-}
+/* ------------------------------------------------------------------ */
+/* Card                                                               */
+/* ------------------------------------------------------------------ */
 
-/*
- * Grid items default to min-width: auto, which prevents tracks from
- * shrinking below their content's min-content width. Force 0 so long
- * unbreakable strings (e.g. JSON dumps) don't blow out the layout.
- */
-.test-case-row > * {
-  min-width: 0;
+.test-case-row {
+  background: var(--background);
+  border: var(--border-width) solid var(--border);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
 }
 
 .test-case-row:hover {
+  border-color: var(--border-strong);
+}
+
+.test-case-row[open] {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Highlight effect for newly added test cases */
+.test-case-row--highlight {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 4px var(--ring-soft);
+  animation: highlight-pulse var(--duration-highlight-animation) ease-in-out;
+}
+
+@keyframes highlight-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--ring) 40%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 8px color-mix(in srgb, var(--ring) 20%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Summary (collapsed header — always visible)                        */
+/* ------------------------------------------------------------------ */
+
+.test-case-row__summary {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  user-select: none;
+  list-style: none;
+  background: transparent;
+  transition: background-color 150ms ease;
+}
+
+.test-case-row__summary:hover {
   background: var(--muted);
 }
 
-/* Input Column Element */
-.test-case-row__input-column {
-  padding: var(--spacing-5);
-  background: var(--background);
-  border-right: var(--border-width) solid var(--border);
+/* Hide native disclosure markers so we can render our own chevron. */
+.test-case-row__summary::-webkit-details-marker {
+  display: none;
 }
+
+.test-case-row__summary::marker {
+  display: none;
+  content: '';
+}
+
+/* Custom chevron — rotates 90° when the card is open. Same look as the
+ * "More options" and "Chat history" disclosures so the row feels visually
+ * consistent. */
+.test-case-row__summary::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 6px solid var(--muted-foreground);
+  transition:
+    transform 200ms ease,
+    border-left-color 150ms ease;
+  transform-origin: 25% 50%;
+  flex-shrink: 0;
+}
+
+.test-case-row__summary:hover::before {
+  border-left-color: var(--foreground);
+}
+
+.test-case-row[open] .test-case-row__summary::before {
+  transform: rotate(90deg);
+  border-left-color: var(--foreground);
+}
+
+/* Question preview — clamped to 2 lines with ellipsis. */
+.test-case-row__question-preview {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-snug);
+  color: var(--foreground);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-clamp: 2;
+  overflow: hidden;
+  line-height: 1.45;
+}
+
+/* Empty / placeholder question gets muted treatment. */
+.test-case-row__question-preview:empty,
+.test-case-row__question-preview:first-letter:lang(en) {
+  /* No-op selector — placeholder coloring is applied via parent state */
+}
+
+/* The actions cluster on the right side of the summary. */
+.test-case-row__summary-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  flex-shrink: 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Status pill — Not run / Running / Passed / Failed                  */
+/* ------------------------------------------------------------------ */
+
+.test-case-row__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
+  font-size: 11px;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-snug);
+  border: var(--border-width) solid transparent;
+  white-space: nowrap;
+}
+
+.test-case-row__status::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.test-case-row__status--not-run {
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border-color: var(--border);
+}
+
+.test-case-row__status--running {
+  background: rgb(59 130 246 / 0.1);
+  color: var(--ring);
+  border-color: rgb(59 130 246 / 0.25);
+}
+
+/* Running dot pulses gently to signal live activity. */
+.test-case-row__status--running::before {
+  animation: test-case-row-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes test-case-row-pulse {
+  0%, 100% { opacity: 0.4; transform: scale(0.85); }
+  50% { opacity: 1; transform: scale(1); }
+}
+
+.test-case-row__status--passed {
+  background: var(--success-soft-bg);
+  color: var(--success-soft-fg);
+  border-color: var(--success-soft-border);
+}
+
+.test-case-row__status--failed {
+  background: var(--destructive-soft-bg);
+  color: var(--destructive-soft-fg);
+  border-color: var(--destructive-soft-border);
+}
+
+.test-case-row__status--partial {
+  background: var(--warning-soft-bg);
+  color: var(--warning-soft-fg);
+  border-color: var(--warning-soft-border);
+  font-weight: var(--font-weight-semibold);
+}
+
+/* ------------------------------------------------------------------ */
+/* Body (expanded — the existing 3-column editor)                     */
+/* ------------------------------------------------------------------ */
+
+/* Body — vertical stack: Input on top (always when expanded), Output +
+ * Evaluation appear below as a 2-column grid only when the test has
+ * been run (or is currently running). Fresh test cases stay compact. */
+.test-case-row__body {
+  display: flex;
+  flex-direction: column;
+  border-top: var(--border-width) solid var(--border);
+  background: var(--background);
+}
+
+/* Output + Evaluation row — visually distinct from the input section
+ * above. Sits on a muted "tray" with its own bordered, rounded sub-cards
+ * for Output and Evaluation. The shift in background + the inset
+ * sub-cards signal "this is the result of the test", separate from the
+ * editor that produced it. */
+.test-case-row__results {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  background: var(--muted);
+  border-top: var(--border-width) solid var(--border);
+}
+
+.test-case-row__results > * {
+  min-width: 0;
+}
+
+/* Each panel: a small uppercase header strip + flexible content area. */
+.test-case-row__panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+/* Panels inside the results tray become their own bordered sub-cards
+ * with a white background — they "sit on" the muted tray. */
+.test-case-row__results .test-case-row__panel {
+  background: var(--background);
+  border: var(--border-width) solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.test-case-row__panel-header {
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wider);
+  color: var(--muted-foreground);
+  background: var(--muted);
+  border-bottom: var(--border-width) solid var(--border);
+}
+
+.test-case-row__panel-content {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Input column keeps its own padding rules (the existing
+ * input-content > textarea / chat-history / expected-outcome layout). */
+.test-case-row__input-content {
+  flex: 1;
+  padding: var(--spacing-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+/* The Run footer that used to live at the bottom of the input column is
+ * removed — the Run button is now in the summary, always reachable
+ * without expanding the card. */
+
+/* ------------------------------------------------------------------ */
+/* Expected outcome renderer (within input column)                    */
+/* ------------------------------------------------------------------ */
 
 .expected-outcome-renderer {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-4);
-  margin-top: var(--spacing-4);
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-2);
 }
 
 .expected-outcome-renderer__group {
@@ -40,50 +289,119 @@
   gap: var(--spacing-2);
   padding: var(--spacing-3);
   border: var(--border-width) solid var(--border);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   background: var(--background);
+  transition: border-color 150ms ease;
+}
+
+.expected-outcome-renderer__group:focus-within {
+  border-color: var(--border-strong);
 }
 
 .expected-outcome-renderer__options {
   border: var(--border-width) solid var(--border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-lg);
+  background: transparent;
+  overflow: hidden;
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.expected-outcome-renderer__options[open] {
   background: var(--muted);
+  border-color: var(--border-strong);
 }
 
 .expected-outcome-renderer__options-summary {
   cursor: pointer;
-  font-size: var(--font-size-sm);
-  color: var(--foreground);
-  padding: var(--spacing-2) var(--spacing-3);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wider);
+  color: var(--muted-foreground);
+  padding: var(--spacing-3) var(--spacing-3);
   user-select: none;
+  list-style: none;
+  transition: color 150ms ease;
+}
+
+.expected-outcome-renderer__options-summary:hover {
+  color: var(--foreground);
+}
+
+.expected-outcome-renderer__options-summary::-webkit-details-marker {
+  display: none;
+}
+
+.expected-outcome-renderer__options-summary::marker {
+  display: none;
+  content: '';
+}
+
+.expected-outcome-renderer__options-summary::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor;
+  transition: transform 200ms ease;
+  transform-origin: 25% 50%;
+  flex-shrink: 0;
+}
+
+.expected-outcome-renderer__options[open]
+  .expected-outcome-renderer__options-summary::before {
+  transform: rotate(90deg);
 }
 
 .expected-outcome-renderer__options-content {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-2);
+  gap: var(--spacing-3);
   padding: 0 var(--spacing-3) var(--spacing-3);
 }
 
-/* Responsive Design */
+/* ------------------------------------------------------------------ */
+/* Responsive                                                         */
+/* ------------------------------------------------------------------ */
+
 @media (max-width: 1200px) {
-  .test-case-row {
+  .test-case-row__results {
     grid-template-columns: 1fr;
-    gap: 0;
   }
 
-  .test-case-row__input-column {
+  .test-case-row__results .test-case-row__panel {
     border-right: none;
     border-bottom: var(--border-width) solid var(--border);
+  }
+
+  .test-case-row__results .test-case-row__panel:last-child {
+    border-bottom: none;
   }
 }
 
 @media (max-width: 768px) {
-  .test-case-row__input-column {
-    padding: var(--spacing-4);
+  .test-case-row__summary {
+    padding: var(--spacing-3);
+    flex-wrap: wrap;
   }
 
-  .test-case-row {
-    min-height: auto;
+  .test-case-row__question-preview {
+    flex: 1 1 100%;
+    order: 1;
+  }
+
+  .test-case-row__summary-actions {
+    order: 2;
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .test-case-row__input-content {
+    padding: var(--spacing-4);
   }
 }

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.spec.tsx
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.spec.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect } from '@jest/globals';
+import { computeTestStatus } from './llm-test-case-row';
+import type { TestCase } from '../../../types/llm-test-runner';
+import type {
+  EvaluationResult,
+  FieldEvaluationResult,
+} from '../../../lib/evaluation/types';
+
+function makeTestCase(partial: {
+  isRunning?: boolean;
+  evaluationResult?: Partial<EvaluationResult>;
+}): TestCase {
+  return partial as unknown as TestCase;
+}
+
+function fieldResult(passed: boolean, error?: string): FieldEvaluationResult {
+  return { passed, error } as unknown as FieldEvaluationResult;
+}
+
+describe('computeTestStatus', () => {
+  it('returns "running" when the test case is in flight', () => {
+    const status = computeTestStatus(makeTestCase({ isRunning: true }));
+    expect(status).toEqual({ kind: 'running', label: 'Running' });
+  });
+
+  it('returns "not-run" when there is no evaluation result', () => {
+    const status = computeTestStatus(makeTestCase({}));
+    expect(status).toEqual({ kind: 'not-run', label: 'Not run' });
+  });
+
+  it('returns "passed" for a single-field result that passed', () => {
+    const status = computeTestStatus(
+      makeTestCase({ evaluationResult: { passed: true } }),
+    );
+    expect(status).toEqual({ kind: 'passed', label: 'Passed' });
+  });
+
+  it('returns "failed" for a single-field result that failed', () => {
+    const status = computeTestStatus(
+      makeTestCase({ evaluationResult: { passed: false } }),
+    );
+    expect(status).toEqual({ kind: 'failed', label: 'Failed' });
+  });
+
+  it('returns "passed" when every field result passed cleanly', () => {
+    const status = computeTestStatus(
+      makeTestCase({
+        evaluationResult: {
+          passed: true,
+          fieldResults: [fieldResult(true), fieldResult(true)],
+        },
+      }),
+    );
+    expect(status).toEqual({ kind: 'passed', label: 'Passed' });
+  });
+
+  it('returns "failed" when no field result passed', () => {
+    const status = computeTestStatus(
+      makeTestCase({
+        evaluationResult: {
+          passed: false,
+          fieldResults: [fieldResult(false), fieldResult(false)],
+        },
+      }),
+    );
+    expect(status).toEqual({ kind: 'failed', label: 'Failed' });
+  });
+
+  it('returns "partial" with a "X of Y tests passed" label when some pass and some fail', () => {
+    const status = computeTestStatus(
+      makeTestCase({
+        evaluationResult: {
+          passed: false,
+          fieldResults: [
+            fieldResult(true),
+            fieldResult(false),
+            fieldResult(true),
+          ],
+        },
+      }),
+    );
+    expect(status).toEqual({
+      kind: 'partial',
+      label: '2 of 3 tests passed',
+    });
+  });
+
+  it('treats a passed field with an error as not-passed (does not inflate partial count)', () => {
+    const status = computeTestStatus(
+      makeTestCase({
+        evaluationResult: {
+          passed: false,
+          fieldResults: [
+            fieldResult(true),
+            fieldResult(true, 'boom'),
+            fieldResult(false),
+          ],
+        },
+      }),
+    );
+    // Only one field really passes — the "passed but errored" one should not
+    // be counted toward the partial total.
+    expect(status).toEqual({
+      kind: 'partial',
+      label: '1 of 3 tests passed',
+    });
+  });
+});

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.tsx
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.tsx
@@ -2,7 +2,9 @@ import { h, FunctionalComponent } from '@stencil/core';
 import { TestCase } from '../../../types/llm-test-runner';
 import { ResponseOutput } from './output/response-output';
 import { EvaluationSummary } from './evaluation/evaluation-summary';
-import { RowActions } from './actions/row-actions';
+import { Button } from '../../../lib/ui/button/index';
+import { IconButton } from '../../../lib/ui/icon-button/index';
+import { PlayIcon, SpinnerIcon, TrashIcon } from '../../../lib/ui/icons/icons';
 import { FormFieldType, TextAreaConfig } from '../../../lib/form/schema';
 import {
   ExpectedOutcomeChangeDetail,
@@ -29,6 +31,55 @@ export interface LLMTestCaseRowProps {
   onChatHistoryChange: (e: CustomEvent<ChatHistoryRowChangeDetail>) => void;
 }
 
+type StatusKind = 'not-run' | 'running' | 'passed' | 'failed' | 'partial';
+
+interface TestStatus {
+  kind: StatusKind;
+  label: string;
+}
+
+const STATUS_LABEL: Record<StatusKind, string> = {
+  'not-run': 'Not run',
+  running: 'Running',
+  passed: 'Passed',
+  failed: 'Failed',
+  partial: 'Partial',
+};
+
+interface FieldResultCounts {
+  passed: number;
+  total: number;
+}
+
+/** Count how many field results pass cleanly (passed and no error). */
+function countFieldResults(
+  fieldResults: ReadonlyArray<{ passed: boolean; error?: unknown }>,
+): FieldResultCounts {
+  const passed = fieldResults.filter(field => field.passed && !field.error).length;
+  return { passed, total: fieldResults.length };
+}
+
+export function computeTestStatus(testCase: TestCase): TestStatus {
+  if (testCase.isRunning) return { kind: 'running', label: STATUS_LABEL.running };
+  if (!testCase.evaluationResult) return { kind: 'not-run', label: STATUS_LABEL['not-run'] };
+
+  const fieldResults = testCase.evaluationResult.fieldResults;
+  if (fieldResults && fieldResults.length > 1) {
+    const { passed, total } = countFieldResults(fieldResults);
+
+    if (passed > 0 && passed < total) {
+      const noun = total === 1 ? 'test' : 'tests';
+      return { kind: 'partial', label: `${passed} of ${total} ${noun} passed` };
+    }
+
+    const kind: StatusKind = passed === total ? 'passed' : 'failed';
+    return { kind, label: STATUS_LABEL[kind] };
+  }
+
+  const kind: StatusKind = testCase.evaluationResult.passed ? 'passed' : 'failed';
+  return { kind, label: STATUS_LABEL[kind] };
+}
+
 export const LLMTestCaseRow: FunctionalComponent<LLMTestCaseRowProps> = ({
   testCase,
   dynamicResolutionSupported = false,
@@ -48,59 +99,123 @@ export const LLMTestCaseRow: FunctionalComponent<LLMTestCaseRowProps> = ({
     required: true,
     rows: 3,
   };
+
+  const canRun = !!testCase.question.trim();
+  const isRunning = testCase.isRunning;
+  const status = computeTestStatus(testCase);
+  const questionPreview = testCase.question.trim() || 'New test — click to add a question.';
+  const hasResults =
+    isRunning || !!testCase.output?.text || !!testCase.evaluationResult;
+
+  const stopToggle = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
   return (
-    <div class="test-case-row" key={testCase.id}>
-      <div class="test-case-row__input-column">
-        <app-textarea
-          config={questionConfig}
-          value={testCase.question}
-          onValueChange={(e) =>
-            handleTestCaseChange({
-              detail: {
-                testCaseId: testCase.id,
-                key: 'question',
-                value: e.detail.value,
-              },
-            } as CustomEvent<{ testCaseId: string; key: string; value: string }>)
-          }
-        />
-        <chat-history
-          chatHistoryEnabled={testCase.chatHistory?.enabled ?? false}
-          chatHistoryValue={testCase.chatHistory?.value ?? ''}
-          onChatHistoryChange={(e: Event) => {
-            const { enabled, value } = (e as CustomEvent<ChatHistoryChangeDetail>)
-              .detail;
-            onChatHistoryChange({
-              detail: {
-                testCaseId: testCase.id,
-                enabled,
-                value,
-              },
-            } as CustomEvent<ChatHistoryRowChangeDetail>);
-          }}
-        />
-        <ExpectedOutcomeRenderer
-          testCaseId={testCase.id}
-          fields={testCase.expectedOutcome || []}
-          dynamicResolutionSupported={dynamicResolutionSupported}
-          extractorIds={extractorIds}
-          onExpectedOutcomeChange={onExpectedOutcomeChange}
-        />
+    <details class="test-case-row" key={testCase.id} data-test-case-id={testCase.id}>
+      <summary class="test-case-row__summary">
+        <span class="test-case-row__question-preview" title={testCase.question}>
+          {questionPreview}
+        </span>
+        <div class="test-case-row__summary-actions">
+          <span
+            class={`test-case-row__status test-case-row__status--${status.kind}`}
+          >
+            {status.label}
+          </span>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={(e) => {
+              stopToggle(e as MouseEvent);
+              onRun(testCase);
+            }}
+            disabled={isRunning || !canRun}
+            loading={isRunning}
+            icon={isRunning ? <SpinnerIcon /> : <PlayIcon />}
+            aria-label={canRun ? 'Run this test' : 'Enter a question first'}
+          >
+            {isRunning ? 'Running' : 'Run'}
+          </Button>
+          <IconButton
+            variant="outline"
+            onClick={(e) => {
+              stopToggle(e as MouseEvent);
+              onDelete(testCase.id);
+            }}
+            title="Delete this test"
+          >
+            <TrashIcon />
+          </IconButton>
+        </div>
+      </summary>
+
+      <div class="test-case-row__body">
+        <section class="test-case-row__panel test-case-row__panel--input">
+          <header class="test-case-row__panel-header">Input</header>
+          <div class="test-case-row__input-content">
+            <app-textarea
+              config={questionConfig}
+              value={testCase.question}
+              onValueChange={(e) =>
+                handleTestCaseChange({
+                  detail: {
+                    testCaseId: testCase.id,
+                    key: 'question',
+                    value: e.detail.value,
+                  },
+                } as CustomEvent<{ testCaseId: string; key: string; value: string }>)
+              }
+            />
+            <chat-history
+              chatHistoryEnabled={testCase.chatHistory?.enabled ?? false}
+              chatHistoryValue={testCase.chatHistory?.value ?? ''}
+              onChatHistoryChange={(e: Event) => {
+                const { enabled, value } = (e as CustomEvent<ChatHistoryChangeDetail>)
+                  .detail;
+                onChatHistoryChange({
+                  detail: {
+                    testCaseId: testCase.id,
+                    enabled,
+                    value,
+                  },
+                } as CustomEvent<ChatHistoryRowChangeDetail>);
+              }}
+            />
+            <ExpectedOutcomeRenderer
+              testCaseId={testCase.id}
+              fields={testCase.expectedOutcome || []}
+              dynamicResolutionSupported={dynamicResolutionSupported}
+              extractorIds={extractorIds}
+              onExpectedOutcomeChange={onExpectedOutcomeChange}
+            />
+          </div>
+        </section>
+        {hasResults && (
+          <div class="test-case-row__results">
+            <section class="test-case-row__panel">
+              <header class="test-case-row__panel-header">Output</header>
+              <div class="test-case-row__panel-content">
+                <ResponseOutput
+                  output={testCase.output}
+                  isRunning={testCase.isRunning}
+                />
+              </div>
+            </section>
+
+            <section class="test-case-row__panel">
+              <header class="test-case-row__panel-header">Evaluation</header>
+              <div class="test-case-row__panel-content">
+                <EvaluationSummary
+                  result={testCase.evaluationResult}
+                  isRunning={testCase.isRunning}
+                />
+              </div>
+            </section>
+          </div>
+        )}
       </div>
-
-      <ResponseOutput output={testCase.output} isRunning={testCase.isRunning} />
-
-      <EvaluationSummary
-        result={testCase.evaluationResult}
-        isRunning={testCase.isRunning}
-      />
-
-      <RowActions
-        isRunning={testCase.isRunning}
-        canRun={!!testCase.question.trim()}
-        onRun={() => onRun(testCase)}
-        onDelete={() => onDelete(testCase.id)}
-      />
-    </div>
+    </details>
   );
 };

--- a/src/components/llm-test-runner/test-cases/llm-test-cases.css
+++ b/src/components/llm-test-runner/test-cases/llm-test-cases.css
@@ -1,39 +1,19 @@
-/* Test Cases Block */
+/* Test Cases — vertical stack of self-contained collapsible cards, one
+ * per test case. Cards collapse to a compact summary (question preview +
+ * status badge + Run / Delete) and expand to reveal the full editor and
+ * results in a 3-column layout. */
 .test-cases {
-  background: var(--background);
-}
-
-/* Column Headers Element */
-.test-cases__column-headers {
-  display: grid;
-  grid-template-columns: 1fr 1.5fr 0.5fr 120px;
-  gap: var(--border-width);
-  background: var(--border);
-  border-bottom: 2px solid var(--border);
-}
-
-.test-cases__column-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  padding: var(--spacing-5);
   background: var(--muted);
-  padding: var(--spacing-4) var(--spacing-5);
-  font-weight: var(--font-weight-semibold);
-  color: var(--foreground);
-  font-size: var(--font-size-sm);
-  text-transform: uppercase;
-  letter-spacing: var(--letter-spacing-wide);
+  padding-top: var(--spacing-2);
 }
 
-/* Add Test Case Element */
-.test-cases__add-section {
-  padding: var(--spacing-6);
-  text-align: center;
-  background: var(--muted);
-  border-top: var(--border-width) solid var(--border);
-}
-
-/* Responsive Design */
-@media (max-width: 1200px) {
-  .test-cases__column-headers {
-    display: none;
+@media (max-width: 768px) {
+  .test-cases {
+    padding: var(--spacing-4);
+    gap: var(--spacing-2);
   }
 }
-

--- a/src/components/llm-test-runner/test-cases/llm-test-cases.tsx
+++ b/src/components/llm-test-runner/test-cases/llm-test-cases.tsx
@@ -1,7 +1,6 @@
 import { h, FunctionalComponent } from '@stencil/core';
 import { TestCase } from '../../../types/llm-test-runner';
 import { LLMTestCaseRow, ChatHistoryRowChangeDetail } from './llm-test-case-row';
-import { Button } from '../../../lib/ui/button/index';
 import { ExpectedOutcomeChangeDetail } from './expected-outcome-renderer';
 
 export interface LLMTestCasesProps {
@@ -10,7 +9,6 @@ export interface LLMTestCasesProps {
   extractorIds?: string[];
   onRun: (testCase: TestCase) => void;
   onDelete: (id: string) => void;
-  onAddTestCase: () => void;
   handleTestCaseChange: (
     e: CustomEvent<{ testCaseId: string; key: string; value: string }>,
   ) => void;
@@ -26,20 +24,12 @@ export const LLMTestCases: FunctionalComponent<LLMTestCasesProps> = ({
   extractorIds = [],
   onRun,
   onDelete,
-  onAddTestCase,
   handleTestCaseChange,
   onExpectedOutcomeChange,
   onChatHistoryChange,
 }) => {
   return (
     <div class="test-cases">
-      <div class="test-cases__column-headers">
-        <div class="test-cases__column-header">Input</div>
-        <div class="test-cases__column-header">Output</div>
-        <div class="test-cases__column-header">Evaluation</div>
-        <div class="test-cases__column-header">Actions</div>
-      </div>
-
       {testCases.map(testCase => (
         <LLMTestCaseRow
           testCase={testCase}
@@ -52,12 +42,6 @@ export const LLMTestCases: FunctionalComponent<LLMTestCasesProps> = ({
           onChatHistoryChange={onChatHistoryChange}
         />
       ))}
-
-      <div class="test-cases__add-section">
-        <Button variant="outline" size="md" onClick={onAddTestCase}>
-          + Add Question
-        </Button>
-      </div>
     </div>
   );
 };

--- a/src/components/llm-test-runner/test-cases/output/response-output.css
+++ b/src/components/llm-test-runner/test-cases/output/response-output.css
@@ -1,10 +1,10 @@
 /* Response Output Block */
 .response-output {
-  padding: var(--spacing-5);
+  padding: var(--spacing-4);
   background: var(--background);
-  border-right: var(--border-width) solid var(--border);
   display: flex;
   flex-direction: column;
+  flex: 1;
 }
 
 .response-output__toolbar {
@@ -36,38 +36,68 @@
   align-items: center;
   justify-content: center;
   color: var(--muted-foreground);
-  font-style: italic;
+  font-size: var(--font-size-sm);
   flex: 1;
   background: var(--muted);
-  border: 2px dashed var(--border);
   border-radius: var(--radius);
+  padding: var(--spacing-4);
+  min-width: 0;
+  text-align: center;
+}
+
+/* ----- Skeleton (live, while model is responding) ----- */
+
+.response-output__skeleton {
+  flex: 1;
+  background: var(--muted);
+  border-radius: var(--radius);
+  padding: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   min-width: 0;
 }
 
-.response-output__placeholder--running {
-  animation: placeholder-pulse 1.6s ease-in-out infinite;
+.skeleton-line {
+  height: 12px;
+  border-radius: var(--radius-full);
+  background:
+    linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.06) 0%,
+      rgba(0, 0, 0, 0.12) 50%,
+      rgba(0, 0, 0, 0.06) 100%
+    );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
 }
 
-.response-output__placeholder-text::after {
-  content: '...';
-  display: inline-block;
-  width: 0;
-  overflow: hidden;
-  vertical-align: bottom;
-  animation: placeholder-dots 1.4s steps(4) infinite;
+.skeleton-line--w-100 { width: 100%; }
+.skeleton-line--w-95  { width: 95%; }
+.skeleton-line--w-90  { width: 90%; }
+.skeleton-line--w-85  { width: 85%; }
+.skeleton-line--w-80  { width: 80%; }
+.skeleton-line--w-70  { width: 70%; }
+.skeleton-line--w-60  { width: 60%; }
+.skeleton-line--w-50  { width: 50%; }
+.skeleton-line--w-40  { width: 40%; }
+
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
 }
 
-/* Responsive Design */
-@media (max-width: 1200px) {
-  .response-output {
-    border-right: none;
-    border-bottom: var(--border-width) solid var(--border);
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-line {
+    animation: none;
+    opacity: 0.7;
   }
 }
 
+/* Responsive Design */
 @media (max-width: 768px) {
   .response-output {
-    padding: var(--spacing-4);
+    padding: var(--spacing-3);
   }
 }
 

--- a/src/components/llm-test-runner/test-cases/output/response-output.tsx
+++ b/src/components/llm-test-runner/test-cases/output/response-output.tsx
@@ -10,6 +10,11 @@ export const ResponseOutput: FunctionalComponent<ResponseOutputProps> = ({
   output,
   isRunning,
 }) => {
+  // While the model is generating and we don't yet have a response, show
+  // a skeleton that mimics the eventual prose layout. Reads as "something
+  // is happening here" without the dead-air "Running…" placeholder.
+  const showSkeleton = isRunning && !output?.text;
+
   return (
     <div class="response-output">
       <div class="response-output__toolbar">
@@ -17,16 +22,21 @@ export const ResponseOutput: FunctionalComponent<ResponseOutputProps> = ({
       </div>
       {output?.text ? (
         <div class="response-output__content">{output.text}</div>
-      ) : (
+      ) : showSkeleton ? (
         <div
-          class={{
-            'response-output__placeholder': true,
-            'response-output__placeholder--running': isRunning,
-          }}
+          class="response-output__skeleton"
+          aria-busy="true"
+          aria-label="Generating response"
         >
-          {isRunning && (
-            <span class="response-output__placeholder-text">Running</span>
-          )}
+          <div class="skeleton-line skeleton-line--w-95"></div>
+          <div class="skeleton-line skeleton-line--w-100"></div>
+          <div class="skeleton-line skeleton-line--w-85"></div>
+          <div class="skeleton-line skeleton-line--w-70"></div>
+          <div class="skeleton-line skeleton-line--w-90"></div>
+        </div>
+      ) : (
+        <div class="response-output__placeholder">
+          Run the test to see the model's response.
         </div>
       )}
     </div>

--- a/src/components/llm-test-runner/tests/runAllTest.spec.tsx
+++ b/src/components/llm-test-runner/tests/runAllTest.spec.tsx
@@ -129,7 +129,7 @@ describe('LLMTestRunner - Run All', () => {
 
     // 1. Trigger "Run All".
     const runButtonAll = page.root.shadowRoot.querySelector(
-      'button[aria-label="Run All"]',
+      'button[aria-label="Run all"]',
     ) as HTMLButtonElement;
     runButtonAll.click();
 
@@ -188,7 +188,7 @@ describe('LLMTestRunner - Run All', () => {
     page.root.addEventListener('llmRequest', llmRequestSpy);
 
     const runButtonAll = page.root.shadowRoot.querySelector(
-      'button[aria-label="Run All"]',
+      'button[aria-label="Run all"]',
     ) as HTMLButtonElement;
     runButtonAll.click();
     await page.waitForChanges();
@@ -216,7 +216,7 @@ describe('LLMTestRunner - Run All', () => {
     page.root.addEventListener('llmRequest', llmRequestSpy);
 
     const runButtonAll = page.root.shadowRoot.querySelector(
-      'button[aria-label="Run All"]',
+      'button[aria-label="Run all"]',
     ) as HTMLButtonElement;
     runButtonAll.click();
 

--- a/src/components/llm-test-runner/tests/runSingleTest.spec.tsx
+++ b/src/components/llm-test-runner/tests/runSingleTest.spec.tsx
@@ -74,7 +74,7 @@ describe('LLMTestRunner', () => {
     page.root.addEventListener('llmRequest', llmRequestSpy);
 
     const runButton = page.root.shadowRoot.querySelector(
-      'button[title="Run this test"]',
+      'button[aria-label="Run this test"]',
     ) as HTMLButtonElement;
     runButton.click();
 
@@ -107,7 +107,7 @@ describe('LLMTestRunner', () => {
     page.root.addEventListener('llmRequest', llmRequestSpy);
 
     const runButton = page.root.shadowRoot.querySelector(
-      'button[title="Run this test"]',
+      'button[aria-label="Run this test"]',
     ) as HTMLButtonElement;
     runButton.click();
     await page.waitForChanges();
@@ -129,7 +129,7 @@ describe('LLMTestRunner', () => {
     page.root.addEventListener('llmRequest', llmRequestSpy);
 
     const runButton = page.root.shadowRoot.querySelector(
-      'button[title="Run this test"]',
+      'button[aria-label="Run this test"]',
     ) as HTMLButtonElement;
     runButton.click();
     await page.waitForChanges();
@@ -146,7 +146,7 @@ describe('LLMTestRunner', () => {
     page.root.addEventListener('llmRequest', llmRequestSpy);
 
     const runButton = page.root.shadowRoot.querySelector(
-      'button[title="Run this test"]',
+      'button[aria-label="Run this test"]',
     ) as HTMLButtonElement;
 
     runButton.click();
@@ -179,7 +179,7 @@ describe('LLMTestRunner', () => {
     page.root.addEventListener('llmRequest', llmRequestSpy);
 
     const runButton = page.root.shadowRoot.querySelector(
-      'button[title="Run this test"]',
+      'button[aria-label="Run this test"]',
     ) as HTMLButtonElement;
     runButton.click();
     await page.waitForChanges();
@@ -199,7 +199,7 @@ describe('LLMTestRunner', () => {
     page.root.addEventListener('llmRequest', llmRequestSpy);
 
     const runButton = page.root.shadowRoot.querySelector(
-      'button[title="Run this test"]',
+      'button[aria-label="Run this test"]',
     ) as HTMLButtonElement;
     runButton.click();
     await page.waitForChanges();
@@ -230,7 +230,7 @@ describe('LLMTestRunner', () => {
     page.root.addEventListener('llmRequest', llmRequestSpy);
 
     const runButton = page.root.shadowRoot.querySelector(
-      'button[title="Run this test"]',
+      'button[aria-label="Run this test"]',
     ) as HTMLButtonElement;
     runButton.click();
     await page.waitForChanges();
@@ -267,7 +267,7 @@ describe('LLMTestRunner', () => {
     page.root.addEventListener('llmRequest', llmRequestSpy);
 
     const runButton = page.root.shadowRoot.querySelector(
-      'button[title="Run this test"]',
+      'button[aria-label="Run this test"]',
     ) as HTMLButtonElement;
     runButton.click();
     await page.waitForChanges();
@@ -317,7 +317,7 @@ describe('LLMTestRunner', () => {
     page.root.addEventListener('llmRequest', llmRequestSpy);
 
     const runButton = page.root.shadowRoot.querySelector(
-      'button[title="Run this test"]',
+      'button[aria-label="Run this test"]',
     ) as HTMLButtonElement;
     runButton.click();
     await page.waitForChanges();

--- a/src/demo/vanilla-demo.css
+++ b/src/demo/vanilla-demo.css
@@ -1,71 +1,124 @@
+/* Inter & JetBrains Mono — loaded once at the document level so they're
+ * available inside every Stencil shadow root automatically. */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+:root {
+  --page-padding-x: clamp(16px, 4vw, 40px);
+  --page-padding-y: clamp(16px, 3vw, 32px);
+}
+
+html,
 body {
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100%;
+}
+
+body {
   margin: 0;
-  padding: 20px;
-  background-color: #f5f5f5;
-  color: #333;
+  padding: var(--page-padding-y) var(--page-padding-x);
+  background: #fafafa;
+  color: #18181b;
+  font-family:
+    'Inter', 'Inter Variable', ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-feature-settings: 'cv11', 'ss01', 'ss03';
+  font-size: 14px;
   line-height: 1.5;
+  letter-spacing: -0.005em;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 .container {
-  max-width: 1200px;
+  /* Drop the old 1200px cap — rely on the body's responsive padding for
+   * comfortable reading width on ultra-wide displays without artificially
+   * constricting the test runner. */
+  max-width: none;
+  width: 100%;
   margin: 0 auto;
 }
 
 .demo-section {
-  background: white;
-  margin: 20px 0;
-  padding: 30px;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 h1 {
-  color: #333;
-  text-align: center;
-  margin-bottom: 40px;
+  margin: 0 0 8px;
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: #09090b;
+  text-align: left;
 }
 
 h2 {
-  color: #555;
-  border-bottom: 2px solid #eee;
-  padding-bottom: 10px;
-  margin-top: 0;
+  /* The duplicate "Fluxon LLM TestRunner" h2 reads as redundant chrome
+   * once the page is full-width. Soften it visually so it reads as a
+   * subtle subhead rather than a heavy section banner. */
+  margin: 0 0 4px;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: #71717a;
+  border: none;
+  padding: 0;
+}
+
+.demo-section > p {
+  margin: 0 0 24px;
+  color: #52525b;
+  font-size: 14px;
+  max-width: 680px;
 }
 
 .demo-example-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 10px 14px;
-  margin: 20px 0 20px;
+  gap: 10px 12px;
+  margin: 0 0 24px;
 }
 
 .demo-example-row__label {
-  font-size: 0.9375rem;
-  font-weight: 600;
-  color: #444;
+  font-size: 13px;
+  font-weight: 500;
+  color: #52525b;
+  letter-spacing: -0.005em;
 }
 
 .demo-example-row__select {
   font: inherit;
-  font-size: 0.9375rem;
-  line-height: 1.35;
-  min-width: min(100%, 18rem);
-  min-height: 2.5rem;
-  padding: 0.45rem 0.65rem;
-  border: 1px solid #c4c4c4;
-  border-radius: 6px;
-  background-color: #fff;
-  color: #222;
+  font-size: 13px;
+  line-height: 1.4;
+  min-width: min(100%, 16rem);
+  height: 36px;
+  padding: 0 32px 0 12px;
+  border: 1px solid #e4e4e7;
+  border-radius: 8px;
+  background-color: #ffffff;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><path d="M3 4.5l3 3 3-3" fill="none" stroke="%2371717a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 12px;
+  color: #18181b;
   cursor: pointer;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  appearance: none;
+  -webkit-appearance: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.demo-example-row__select:hover {
+  border-color: #d4d4d8;
 }
 
 .demo-example-row__select:focus-visible {
-  outline: 2px solid #1a56db;
-  outline-offset: 2px;
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 4px rgb(59 130 246 / 0.12);
 }
 
 #runner-host {

--- a/src/lib/form/components/app-select.css
+++ b/src/lib/form/components/app-select.css
@@ -7,18 +7,32 @@
 }
 
 .app-select__select {
+  appearance: none;
+  -webkit-appearance: none;
   border: var(--border-width) solid var(--input);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
+  font-family: inherit;
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
-  padding: var(--spacing-1) var(--spacing-2);
+  letter-spacing: var(--letter-spacing-snug);
+  padding: 6px 30px 6px 10px;
   outline: none;
-  background: var(--background);
+  background-color: var(--background);
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><path d="M3 4.5l3 3 3-3" fill="none" stroke="%2371717a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 12px;
   width: 145px;
   color: var(--foreground);
+  cursor: pointer;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.app-select__select:hover {
+  border-color: var(--border-strong);
 }
 
 .app-select__select:focus {
   border-color: var(--ring);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 4px var(--ring-soft);
 }

--- a/src/lib/form/components/app-textarea.css
+++ b/src/lib/form/components/app-textarea.css
@@ -22,23 +22,29 @@
 }
 
 .textarea-element {
-  width: 95%;
+  width: 100%;
   box-sizing: border-box;
-  padding: var(--spacing-3);
-  border: 2px solid var(--input);
-  border-radius: var(--radius);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: var(--border-width) solid var(--input);
+  border-radius: var(--radius-lg);
   font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  letter-spacing: var(--letter-spacing-snug);
   resize: vertical;
   outline: none;
-  transition: border-color 0.2s ease;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
   font-family: inherit;
   background: var(--background);
   color: var(--foreground);
 }
 
+.textarea-element:hover:not(:read-only):not(:focus) {
+  border-color: var(--border-strong);
+}
+
 .textarea-element:focus {
   border-color: var(--ring);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 4px var(--ring-soft);
 }
 
 .textarea-wrapper--read-only .textarea-label {

--- a/src/lib/ui/button/button.css
+++ b/src/lib/ui/button/button.css
@@ -4,23 +4,55 @@
   align-items: center;
   justify-content: center;
   gap: var(--spacing-2);
-  border-radius: var(--radius);
+  border-radius: var(--radius-lg);
+  font-family: inherit;
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-snug);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    transform 80ms ease;
   border: var(--border-width) solid transparent;
   outline: none;
   position: relative;
   white-space: nowrap;
 }
 
+.ui-button:active:not(:disabled):not(.ui-button--loading) {
+  transform: translateY(0);
+  transition-duration: 50ms;
+}
+
 .ui-button .icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: var(--font-size-base);
+  font-size: 14px; /* default icon size; size variants override below */
   line-height: var(--line-height-none);
+  /* Slightly nudge down so icons sit perfectly with text baselines —
+   * SVG icons render heavier on the top half compared to text glyphs. */
+  margin-top: -1px;
+}
+
+.ui-button .icon svg {
+  width: 1em;
+  height: 1em;
+  display: block;
+}
+
+/* Spinner rotation — reused inside any button while loading. */
+@keyframes ui-button-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.ui-button .icon .icon-spinner {
+  animation: ui-button-spin 1s linear infinite;
+  transform-origin: center;
 }
 
 .ui-button:focus-visible {
@@ -40,32 +72,40 @@
   cursor: wait;
 }
 
-/* Size Variants */
+/* Size Variants — matches Linear / Vercel sizing scale.
+ * Icons are slightly smaller than the text height so they read as
+ * accompanying glyphs rather than competing visual weight. */
 .ui-button--sm {
-  padding: calc(var(--spacing) * 1.5) var(--spacing-3);
+  padding: 4px 10px;
+  height: 28px;
+  gap: 6px;
   font-size: var(--font-size-xs);
 }
 
 .ui-button--sm .icon {
-  font-size: var(--font-size-sm);
+  font-size: 13px;
 }
 
 .ui-button--md {
-  padding: var(--spacing-2) var(--spacing-4);
+  padding: 6px 12px;
+  height: 32px;
+  gap: 6px;
   font-size: var(--font-size-sm);
 }
 
 .ui-button--md .icon {
-  font-size: var(--font-size-base);
+  font-size: 14px;
 }
 
 .ui-button--lg {
-  padding: calc(var(--spacing) * 2.5) var(--spacing-5);
+  padding: 8px 16px;
+  height: 40px;
+  gap: 8px;
   font-size: var(--font-size-base);
 }
 
 .ui-button--lg .icon {
-  font-size: var(--font-size-lg);
+  font-size: 16px;
 }
 
 /* Color Variants */
@@ -77,7 +117,7 @@
 .ui-button--primary:hover:not(:disabled):not(.ui-button--loading) {
   opacity: 0.9;
   transform: translateY(-1px);
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-md);
 }
 
 .ui-button--secondary {
@@ -91,14 +131,14 @@
 }
 
 .ui-button--outline {
-  background: transparent;
+  background: var(--background);
   border-color: var(--border);
   color: var(--foreground);
 }
 
 .ui-button--outline:hover:not(:disabled):not(.ui-button--loading) {
-  background: var(--accent);
-  transform: translateY(-1px);
+  background: var(--muted);
+  border-color: var(--border-strong);
 }
 
 .ui-button--destructive {

--- a/src/lib/ui/button/button.tsx
+++ b/src/lib/ui/button/button.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionalComponent } from '@stencil/core';
+import { h, FunctionalComponent, VNode } from '@stencil/core';
 
 export interface ButtonProps {
   'variant'?: 'primary' | 'secondary' | 'outline' | 'destructive';
@@ -8,7 +8,9 @@ export interface ButtonProps {
   'onClick'?: (event: MouseEvent) => void;
   'type'?: 'button' | 'submit' | 'reset';
   'class'?: string;
-  'icon'?: string;
+  /** A leading icon — accepts a string (legacy emoji/character) or a JSX
+   * node (preferred — see `lib/ui/icons` for the SVG icon set). */
+  'icon'?: string | VNode;
   'aria-label'?: string;
 }
 

--- a/src/lib/ui/criteria-input/criteria-input.css
+++ b/src/lib/ui/criteria-input/criteria-input.css
@@ -12,31 +12,37 @@
 }
 
 .criteria-input__textarea {
-  width: 95%;
+  width: 100%;
   box-sizing: border-box;
-  padding: var(--spacing-3);
-  border: 2px solid var(--input);
-  border-radius: var(--radius);
-  font-size: var(--font-size-sm);
+  padding: var(--spacing-2) var(--spacing-3);
+  border: var(--border-width) solid var(--input);
+  border-radius: var(--radius-lg);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.55;
   resize: vertical;
   outline: none;
-  transition: border-color 0.2s ease;
-  font-family: inherit;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
   background: var(--background);
   color: var(--foreground);
 }
 
-.criteria-input__textarea:focus {
-  border-color: var(--ring);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+.criteria-input__textarea:hover:not(:focus) {
+  border-color: var(--border-strong);
 }
 
-.criteria-input__textarea--error {
+.criteria-input__textarea:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 4px var(--ring-soft);
+}
+
+.criteria-input__textarea--error,
+.criteria-input__textarea--error:hover {
   border-color: var(--destructive);
 }
 
 .criteria-input__textarea--error:focus {
-  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1);
+  box-shadow: 0 0 0 4px var(--destructive-soft-bg);
 }
 
 .criteria-input__error {

--- a/src/lib/ui/icon-button/icon-button.css
+++ b/src/lib/ui/icon-button/icon-button.css
@@ -3,16 +3,39 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: var(--spacing-2);
-  min-width: var(--spacing-10);
-  height: var(--spacing-10);
-  border-radius: var(--radius);
-  font-size: var(--font-size-base);
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-lg);
+  font-size: 16px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    color 120ms ease,
+    transform 80ms ease;
   border: var(--border-width) solid transparent;
   outline: none;
   position: relative;
+  font-family: inherit;
+}
+
+.ui-icon-button svg {
+  width: 16px;
+  height: 16px;
+  display: block;
+}
+
+@keyframes ui-icon-button-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.ui-icon-button .icon-spinner {
+  animation: ui-icon-button-spin 1s linear infinite;
+  transform-origin: center;
 }
 
 .ui-icon-button:focus-visible {
@@ -55,14 +78,15 @@
 }
 
 .ui-icon-button--outline {
-  background: transparent;
+  background: var(--background);
   border-color: var(--border);
-  color: var(--foreground);
+  color: var(--muted-foreground);
 }
 
 .ui-icon-button--outline:hover:not(:disabled):not(.ui-icon-button--loading) {
-  background: var(--accent);
-  transform: translateY(-1px);
+  background: var(--muted);
+  border-color: var(--border-strong);
+  color: var(--foreground);
 }
 
 .ui-icon-button--destructive {

--- a/src/lib/ui/icons/icons.css
+++ b/src/lib/ui/icons/icons.css
@@ -1,0 +1,14 @@
+/* Icon shared styles — kept in a separate file so any host shadow-root
+ * stylesheet can import them via global CSS or be loaded via Stencil's
+ * style mechanism if a particular component needs the spinner animation. */
+
+@keyframes icon-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.icon-spinner {
+  animation: icon-spin 1s linear infinite;
+  transform-origin: center;
+}

--- a/src/lib/ui/icons/icons.tsx
+++ b/src/lib/ui/icons/icons.tsx
@@ -1,0 +1,143 @@
+import { h, FunctionalComponent } from '@stencil/core';
+
+/**
+ * Lucide-style icon set.
+ *
+ * 24×24 viewBox, 2px stroke, rounded line caps & joins, currentColor stroke
+ * — the same visual rhythm as Linear / Vercel / GitHub. Display size is
+ * controlled by the parent (typically 14–16px via the button styles).
+ *
+ * Each icon is a Functional Component that takes no props beyond an
+ * optional class for layout/animation hooks.
+ */
+
+interface IconProps {
+  class?: string;
+}
+
+const baseProps = {
+  width: '1em',
+  height: '1em',
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  'stroke-width': '2',
+  'stroke-linecap': 'round',
+  'stroke-linejoin': 'round',
+  'aria-hidden': 'true',
+} as const;
+
+/** Up-arrow into a tray — used for Import. */
+export const UploadIcon: FunctionalComponent<IconProps> = ({ class: cls }) => (
+  <svg {...baseProps} class={cls}>
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="17 8 12 3 7 8" />
+    <line x1="12" y1="3" x2="12" y2="15" />
+  </svg>
+);
+
+/** Down-arrow out of a tray — used for Export Suite. */
+export const DownloadIcon: FunctionalComponent<IconProps> = ({
+  class: cls,
+}) => (
+  <svg {...baseProps} class={cls}>
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+);
+
+/** Document with text lines — used for Export Test Results. */
+export const FileTextIcon: FunctionalComponent<IconProps> = ({
+  class: cls,
+}) => (
+  <svg {...baseProps} class={cls}>
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <polyline points="14 2 14 8 20 8" />
+    <line x1="16" y1="13" x2="8" y2="13" />
+    <line x1="16" y1="17" x2="8" y2="17" />
+    <polyline points="10 9 9 9 8 9" />
+  </svg>
+);
+
+/** Floppy / save icon — used for Save. */
+export const SaveIcon: FunctionalComponent<IconProps> = ({ class: cls }) => (
+  <svg {...baseProps} class={cls}>
+    <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+    <polyline points="17 21 17 13 7 13 7 21" />
+    <polyline points="7 3 7 8 15 8" />
+  </svg>
+);
+
+/** Sliders — used for Prompt Editor (cleaner than a gear, less "settings"). */
+export const SlidersIcon: FunctionalComponent<IconProps> = ({
+  class: cls,
+}) => (
+  <svg {...baseProps} class={cls}>
+    <line x1="4" y1="21" x2="4" y2="14" />
+    <line x1="4" y1="10" x2="4" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="12" />
+    <line x1="12" y1="8" x2="12" y2="3" />
+    <line x1="20" y1="21" x2="20" y2="16" />
+    <line x1="20" y1="12" x2="20" y2="3" />
+    <line x1="1" y1="14" x2="7" y2="14" />
+    <line x1="9" y1="8" x2="15" y2="8" />
+    <line x1="17" y1="16" x2="23" y2="16" />
+  </svg>
+);
+
+/** Filled play triangle — used for Run / Run All. */
+export const PlayIcon: FunctionalComponent<IconProps> = ({ class: cls }) => (
+  <svg {...baseProps} class={cls} fill="currentColor" stroke="none">
+    <polygon points="6 4 20 12 6 20 6 4" />
+  </svg>
+);
+
+/** Trash can — used for Delete row. */
+export const TrashIcon: FunctionalComponent<IconProps> = ({ class: cls }) => (
+  <svg {...baseProps} class={cls}>
+    <polyline points="3 6 5 6 21 6" />
+    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+    <path d="M10 11v6" />
+    <path d="M14 11v6" />
+    <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
+  </svg>
+);
+
+/** Plus — used for Add Question / Add Test Case. */
+export const PlusIcon: FunctionalComponent<IconProps> = ({ class: cls }) => (
+  <svg {...baseProps} class={cls}>
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+/** Spinner — partial circular arc that rotates. Used for loading states.
+ * The rotation animation is in `icons.css`. */
+export const SpinnerIcon: FunctionalComponent<IconProps> = ({
+  class: cls,
+}) => (
+  <svg
+    {...baseProps}
+    class={['icon-spinner', cls].filter(Boolean).join(' ')}
+  >
+    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+  </svg>
+);
+
+/** Speech-bubble — used for Chat history. */
+export const MessageSquareIcon: FunctionalComponent<IconProps> = ({
+  class: cls,
+}) => (
+  <svg {...baseProps} class={cls}>
+    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+  </svg>
+);
+
+/** X / close — used to remove an optional section. */
+export const XIcon: FunctionalComponent<IconProps> = ({ class: cls }) => (
+  <svg {...baseProps} class={cls}>
+    <line x1="18" y1="6" x2="6" y2="18" />
+    <line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+);

--- a/src/lib/ui/threshold-input/threshold-input.css
+++ b/src/lib/ui/threshold-input/threshold-input.css
@@ -19,14 +19,18 @@
 
 .threshold-input__input {
   width: 100px;
-  padding: var(--spacing-1) var(--spacing-2);
+  padding: 6px 10px;
+  font-family: inherit;
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-snug);
+  font-variant-numeric: tabular-nums;
   border: var(--border-width) solid var(--input);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   background: var(--background);
   color: var(--foreground);
   outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
   /* Hide the native number-input spinner arrows. */
   -moz-appearance: textfield;
   appearance: textfield;
@@ -38,15 +42,19 @@
   margin: 0;
 }
 
+.threshold-input__input:hover:not(:focus) {
+  border-color: var(--border-strong);
+}
+
 .threshold-input__input:focus {
   border-color: var(--ring);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 4px var(--ring-soft);
 }
 
 .threshold-input__input--invalid,
 .threshold-input__input--invalid:focus {
   border-color: var(--destructive);
-  box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.1);
+  box-shadow: 0 0 0 4px var(--destructive-soft-bg);
 }
 
 .threshold-input__message {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -52,9 +52,21 @@
   --line-height-loose: 2;
 
   /* Letter Spacing - Only essential values */
-  --letter-spacing-tight: -0.025em;
+  --letter-spacing-tighter: -0.02em;
+  --letter-spacing-tight: -0.01em;
+  --letter-spacing-snug: -0.005em;
   --letter-spacing-normal: 0;
-  --letter-spacing-wide: 0.05em;
+  --letter-spacing-wide: 0.04em;
+  --letter-spacing-wider: 0.06em;
+
+  /* Font families - load Inter / JetBrains Mono in the host page (see
+   * vanilla-demo.css). Fall back gracefully so the product never breaks
+   * if the webfont fails to load. */
+  --font-family-sans:
+    'Inter', 'Inter Variable', ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-family-mono:
+    'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
 
   /* Shadows */
   --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
@@ -81,6 +93,8 @@
   --opacity-disabled: 0.5;
   --opacity-hover: 0.8;
   --opacity-muted: 0.6;
+
+  --duration-highlight-animation: 1.5s;
 
   /* Max Widths - Common container sizes */
   --max-w-sm: 24rem; /* 384px */
@@ -137,6 +151,23 @@
   /* Info colors */
   --info: #3b82f6;
   --info-foreground: #fafafa;
+
+  --success-soft-bg: rgb(16 185 129 / 0.1);
+  --success-soft-fg: #047857;
+  --success-soft-border: rgb(16 185 129 / 0.2);
+
+  --destructive-soft-bg: rgb(239 68 68 / 0.1);
+  --destructive-soft-fg: #b91c1c;
+  --destructive-soft-border: rgb(239 68 68 / 0.2);
+
+  --warning-soft-bg: rgb(245 158 11 / 0.1);
+  --warning-soft-fg: #b45309;
+  --warning-soft-border: rgb(245 158 11 / 0.25);
+
+  --ring-soft: rgb(59 130 246 / 0.12);
+
+  /* Border emphasis variant for hover/focus-within on cards. */
+  --border-strong: #d4d4d8;
 }
 
 /* Dark theme support - apply data-theme="dark" to the host element */
@@ -166,8 +197,24 @@
   --destructive-foreground: #fafafa;
 
   --border: #27272a;
+  --border-strong: #3f3f46;
   --input: #27272a;
   --ring: #3b82f6;
+
+  /* Soft variants — dark theme */
+  --success-soft-bg: rgb(16 185 129 / 0.15);
+  --success-soft-fg: #34d399;
+  --success-soft-border: rgb(16 185 129 / 0.3);
+
+  --destructive-soft-bg: rgb(239 68 68 / 0.15);
+  --destructive-soft-fg: #f87171;
+  --destructive-soft-border: rgb(239 68 68 / 0.3);
+
+  --warning-soft-bg: rgb(245 158 11 / 0.15);
+  --warning-soft-fg: #fbbf24;
+  --warning-soft-border: rgb(245 158 11 / 0.3);
+
+  --ring-soft: rgb(59 130 246 / 0.18);
 
   --success: #059669;
   --success-foreground: #fafafa;


### PR DESCRIPTION
UI revamp v1 quick rundown:

New icon library at src/lib/ui/icons/
Buttons, criteria input, threshold input, selects, textareas rebuilt on design tokens
Evaluation summary redesigned
Test case rows: cleaner expand state, highlight pulse on new rows



Add test button Moved from bottom of the list to the header (next to import / export / run-all).
Status badge New Partial state — shows "X of Y tests passed" for multi-field evaluations.
Sticky top bar Header stays pinned on scroll. Uses --z-sticky + --shadow-sm tokens.
Layout Removed the fixed-height inner scroll container — overflow now happens at page level.