### PR TITLE
Bump version from 1.4.0 to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 2.0.0 - 2026-05-26
+
+### Added
+
+- Summary dashboard component with live pass-rate, status chips, and total test count
+- `Show summary` toggle in the header
+- `llm-judge` evaluation approach with configurable system + user prompts and per-criterion scoring
+- `llmJudge` prop on `<llm-test-runner>`
+- `evaluating` and `partial` status kinds
+- Animated number transitions on the summary (honors `prefers-reduced-motion`)
+- Highlight animation for newly added test cases
+- Design tokens in `src/styles/tokens.css`
+- Unit tests for `computeTestStatus`
+
+### Changed
+
+- Redesigned test-runner header, row, and evaluation summary
+- Unified field-result counting via `computeTestStatus()`
+- Replaced nested `setTimeout` scroll-and-highlight with `requestAnimationFrame` polling
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## 2.0.0
 
-Version 2 changes and upgrade steps are described in detail on the [version 2 pull request](https://github.com/FluxonApps/llm-testrunner-lib/pull/35).
 
 - New summary dashboard
 - Test-runner UI redesigned
 - LLM-as-judge evaluation approach
 - Richer test status states
 
+## 1.x.x
+
+- Headless assertions for Jest (`toExactMatch`, `toSemanticMatch`, `toRouge1Match`, `toRougeLMatch`, `toBleuMatch`)
+- Built-in evaluators: exact, semantic, ROUGE-1, ROUGE-L, BLEU
+- Test suite import / export and CSV results export
+- Optional save flow
+- Initial test-runner UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,11 @@
 # Changelog
 
-## 2.0.0 - 2026-05-26
+## 2.0.0
 
-### Added
+Version 2 changes and upgrade steps are described in detail on the [version 2 pull request](https://github.com/FluxonApps/llm-testrunner-lib/pull/35).
 
-- Summary dashboard component with live pass-rate, status chips, and total test count
-- `Show summary` toggle in the header
-- `llm-judge` evaluation approach with configurable system + user prompts and per-criterion scoring
-- `llmJudge` prop on `<llm-test-runner>`
-- `evaluating` and `partial` status kinds
-- Animated number transitions on the summary (honors `prefers-reduced-motion`)
-- Highlight animation for newly added test cases
-- Design tokens in `src/styles/tokens.css`
-- Unit tests for `computeTestStatus`
-
-### Changed
-
-- Redesigned test-runner header, row, and evaluation summary
-- Unified field-result counting via `computeTestStatus()`
-- Replaced nested `setTimeout` scroll-and-highlight with `requestAnimationFrame` polling
+- New summary dashboard
+- Test-runner UI redesigned
+- LLM-as-judge evaluation approach
+- Richer test status states
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![npm](https://img.shields.io/npm/v/llm-testrunner-components.svg)](https://www.npmjs.com/package/llm-testrunner-components) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+> **Upgrading from v1.x?** v2 ships a redesigned UI (new class names / DOM), distinct `evaluating` and `partial` test states, and drops the `uuid` dependency. See [`CHANGELOG.md`](CHANGELOG.md) for the full migration notes.
+
 ---
 
 ## Why use this
@@ -19,7 +21,8 @@
 
 - **Test case table** — Add, edit, delete test cases. Each test case has a question, configurable expected-outcome fields (single line, paragraph, keyword chips, dropdown), and a per-field evaluation approach (exact, semantic, ROUGE-1, ROUGE-L, BLEU, llm-judge).
 - **Run one or run all** — Run a single test or batch with a configurable delay between API calls (rate limiting).
-- **Live results** — Pass/fail, keyword match count (e.g. X/Y found), and response time per test.
+- **Live results** — Distinct *running*, *evaluating*, *passed*, *failed*, *partial*, and *not run* states per test. Keyword match count (e.g. X/Y found) and response time included.
+- **Summary dashboard** — A live status bar below the top bar shows pass-rate, passed / failed / not-run chips, and total test count. Toggle on or off via the **Show summary** checkbox in the header.
 - **Import / export** — Import a test suite from JSON. Export the current suite as JSON or export run results as CSV.
 - **Optional save** — When enabled, a Save button emits the current test cases so your app can persist them (e.g. to your backend).
 
@@ -91,7 +94,7 @@ Load the loader and define the custom elements, then listen for `llmRequest` and
 <llm-test-runner id="runner" delay-ms="500"></llm-test-runner>
 
 <script type="module">
-  import { defineCustomElements } from "https://unpkg.com/llm-testrunner-components@1/loader/index.js";
+  import { defineCustomElements } from "https://unpkg.com/llm-testrunner-components@2/loader/index.js";
   defineCustomElements();
 
   const runner = document.getElementById("runner");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-testrunner-components",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-testrunner-components",
-      "version": "1.4.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.40.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-testrunner-components",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "A Stencil web component library for LLM test runner functionality",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",


### PR DESCRIPTION
# v2.0.0

This release is a major UI overhaul plus the introduction of **LLM-as-judge** as a first-class evaluation approach. It also tightens internals — design tokens, status semantics, and a refreshed test-runner shell.

> **Heads up — breaking changes:** the public DOM structure and CSS class names emitted by the test-runner have changed substantially as part of the redesign. Consumers that override styles by class name or rely on internal markup will need to re-skin. Component props remain backwards-compatible.

---

## Highlights

- **Redesigned test-runner UI.** New top bar, sticky header, refreshed typography, design tokens, and a calmer visual language end-to-end.
- **Summary dashboard.** A live status bar sits directly beneath the top bar with pass-rate, passed / failed / not-run chips, and total test count — toggleable from the header.
- **LLM-as-judge evaluator.** Run any field's evaluation through an LLM with system + user prompts, returning per-criterion scores alongside existing approaches (exact, semantic, ROUGE, BLEU).
- **Clearer test status semantics.** Status now distinguishes *running*, *evaluating*, *passed*, *failed*, *partial*, and *not run* — eliminating the old "not run → passed" flicker after an LLM call.

---

## What's new

### UI revamp
- **New header** with import / export / save / run-all controls grouped logically, sticky at the top of the runner.
- **Summary dashboard** beneath the header showing live pass-rate, status chips, and total count. Toggle via the **Show summary** checkbox in the header.
- **Animated number transitions** on the summary — values pop subtly when they change, with `prefers-reduced-motion` honored.
- **Test case row redesign** — cleaner column layout, in-place chat history, expected-outcome renderer, and per-row run / delete actions.
- **Design tokens** centralized in `src/styles/tokens.css` (spacing, radii, colors, z-index, durations) — easier to theme.
- **Highlight animation** for newly added test cases (smooth scroll + flash) replaces the previous timer-chained scroll logic.

### LLM-as-judge evaluation
- New **`llm-judge` evaluation approach** with end-to-end wiring through the evaluation service.
- **Configurable prompts** at both system and user levels for tuning judging behavior.
- **Per-criterion scoring** returned alongside the overall pass / fail decision and surfaced in the row's evaluation summary.
- Pluggable: pass an `llmJudge` prop on `<llm-test-runner>` to inject your own judging function.

### Status & state model
- Status pill now reports **`running`**, **`evaluating`**, **`passed`**, **`failed`**, **`partial`**, and **`not run`** distinctly.
- Partial-pass results (e.g. "2 of 3 tests passed") are first-class — no longer collapsed into a binary pass / fail.
- Field-result aggregation unified through a single `computeTestStatus()` helper used by both the row badge and the summary dashboard.

---

## Breaking changes

- **CSS class names and DOM structure changed** across the test-runner shell, header, row, and evaluation summary. Custom themes / external CSS overrides will need updating.
- **Status taxonomy expanded.** Any consumer reading status from DOM/class selectors should be aware of the new `evaluating` and `partial` kinds.
- **`uuid` dependency removed** in favor of the built-in `crypto.randomUUID()`. No API change for consumers, but anyone importing `uuid` transitively from this package should add it to their own dependencies.

---

## Upgrade notes

1. Update to `^2.0.0` and reinstall — `uuid` is no longer a dependency.
2. If you maintain a custom theme, diff `src/styles/tokens.css` and the new component CSS files; re-skin against the new class names.
3. To opt into LLM-as-judge, pass an `llmJudge` prop on `<llm-test-runner>` and reference the new approach in your expected-outcome `evaluationParameters`.

---


