### PR TITLE
Added release.sh for local version bump + AI-drafted changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,22 @@
 # Changelog
 
+All notable changes to this project are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## 2.0.0
 
+### 🚀 What's new
 
 - New summary dashboard
-- Test-runner UI redesigned
 - LLM-as-judge evaluation approach
-- Richer test status states
+- Richer test status states (evaluating, partial)
+
+### 🔧 Changed
+
+- Test-runner UI redesigned
 
 ## 1.x.x
+
+### 🚀 What's new
 
 - Headless assertions for Jest (`toExactMatch`, `toSemanticMatch`, `toRouge1Match`, `toRougeLMatch`, `toBleuMatch`)
 - Built-in evaluators: exact, semantic, ROUGE-1, ROUGE-L, BLEU

--- a/README.md
+++ b/README.md
@@ -273,6 +273,14 @@ We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get 
 
 ---
 
+## Releasing
+
+Maintainers cut releases locally with `npm run release:patch` / `:minor` / `:major`. The script bumps the version, drafts a sectioned changelog with help from the Claude CLI, opens `$EDITOR` for review, then commits and tags on `main`. See [RELEASING.md](RELEASING.md) for the full flow, conventions, and troubleshooting.
+
+The changelog uses a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)-inspired format with icon-prefixed section headings (`### 🚀 What's new`, `### 🔧 Changed`, `### 🐛 Fixed`, `### 🔒 Security`, …). See [CHANGELOG.md](CHANGELOG.md) for the published history.
+
+---
+
 ## License
 
 The project is licensed under the [MIT License](LICENSE).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,130 @@
+# Releasing
+
+How we cut a release of `llm-testrunner-components`. This document is the single source of truth — keep it short and accurate.
+
+## TL;DR
+
+Releases are local-driven:
+
+1. Run `npm run release:patch` (or `:minor` / `:major`).
+2. Script bumps the version, drafts the changelog with AI assistance, lets you review in `$EDITOR`, then commits and tags locally.
+3. You push the branch and the tag, then publish to npm.
+
+There is no auto-publish CI workflow. The `publish.yml` workflow remains as a manual `workflow_dispatch` fallback for hot-publish scenarios.
+
+## Flow
+
+```
+npm run release:patch
+  ├─ preflight (clean tree, on main, in sync with origin/main)
+  ├─ lint + test + license-check
+  ├─ npm version <bump> --no-git-tag-version
+  ├─ assert vX.Y.Z tag doesn't already exist
+  ├─ Claude CLI drafts CHANGELOG bullets (skipped if `claude` not installed)
+  ├─ $EDITOR opens CHANGELOG.md for review
+  ├─ git commit -m "chore(release): X.Y.Z"
+  └─ git tag -a vX.Y.Z -m "vX.Y.Z"
+
+# Then, manually:
+git push origin main
+git push origin vX.Y.Z
+npm run build-publish
+gh release create vX.Y.Z --notes "..."   # or use the GitHub UI
+```
+
+## Commands
+
+| Command | Result |
+|---------|--------|
+| `npm run release:patch` | 1.4.0 → 1.4.1 |
+| `npm run release:minor` | 1.4.0 → 1.5.0 |
+| `npm run release:major` | 1.4.0 → 2.0.0 |
+| `npm run release -- 2.0.0-rc.1` | explicit version (RC) |
+| `npm run release -- minor --dry-run` | preview every command, change nothing |
+| `npm run release -- patch --no-test` | skip lint+test+license-check |
+
+> `npm run` swallows positional args unless you pass them after `--`. Use the convenience aliases (`:patch` / `:minor` / `:major`) when you can.
+
+## What the script enforces
+
+Steps run in order. Any failure aborts the release.
+
+1. Working tree is clean.
+2. Current branch is `main`.
+3. Local `main` matches `origin/main`.
+4. `lint`, `test`, `license-check` all pass (skippable via `--no-test`).
+5. Bumps version via `npm version <arg> --no-git-tag-version`.
+6. Asserts `vX.Y.Z` does not already exist locally or on origin.
+7. Calls Claude CLI with `git log` + `git diff --stat` since the previous `v*` tag. Asks for 3–7 high-level bullets. Falls back to an empty `- ` stub if `claude` is not installed.
+8. Prepends `## X.Y.Z` plus the bullets to `CHANGELOG.md` and opens `$EDITOR`.
+9. After save, verifies the new section actually has content (not just an empty stub).
+10. `git commit -m "chore(release): X.Y.Z"`.
+11. `git tag -a vX.Y.Z -m "vX.Y.Z"`.
+12. Prints the push, `npm run build-publish`, and `gh release create` commands so you can review before handing off.
+
+**Rollback:** if any step between the version bump and the tag fails, the script restores `package.json`, `package-lock.json`, and `CHANGELOG.md` so the next retry starts clean.
+
+**AI requirement:** none. If the `claude` CLI is on your PATH, the script uses it. If not, you get an empty stub to fill in by hand.
+
+## Manual steps after the script
+
+The script stops after the local tag. You drive the rest:
+
+```bash
+# 1. Push the branch and the tag
+git push origin main <branch_name>
+git push origin vX.Y.Z
+
+# 2. Publish to npm (If you chose to do it locally)
+npm run build-publish
+
+# 3. Create the GitHub Release (mirrors the CHANGELOG section as the body)
+gh release create vX.Y.Z \
+  --title "vX.Y.Z" \
+  --notes "$(awk -v ver=\"X.Y.Z\" '
+    $0 == \"## \" ver { found=1; next }
+    found && /^## / { exit }
+    found { print }
+  ' CHANGELOG.md)"
+```
+
+The script prints all three command groups at the end, ready to copy-paste with the correct version filled in.
+
+## Conventions
+
+- **Tag format:** `vX.Y.Z` (matches the existing `v1.3.5-internal.0` style).
+- **Release commit:** `chore(release): X.Y.Z` (Conventional Commits).
+- **Branches:** releases cut only from `main`. Feature branches merge to `main` via PR first.
+- **Pre-releases:** suffix with `-rc.N` (e.g. `2.0.0-rc.1`). Publish these under the `next` dist-tag manually: `npm publish --tag next --access=public` — the script does not branch on this yet.
+- **Migration notes:** for majors, link to the version PR from the corresponding `## X.0.0` section of `CHANGELOG.md`.
+
+## Why this design
+
+| Concern | How we handle it |
+|---------|-----------------|
+| Single source of truth for what shipped | Tag commit contains the matching `CHANGELOG.md` entry. |
+| Avoid "tag updates changelog" chicken-and-egg | Local script does the bump + changelog before tagging. |
+| Branch protection on `main` | No CI ever pushes to `main`. |
+| Cost / API key sprawl | AI runs locally using the developer's existing Claude CLI auth. Zero new GitHub secrets. |
+| Human review of AI output | Script opens `$EDITOR` after AI drafts. You always see the changelog before it's committed. |
+| Wrong version published | Local preflight + `npm version` keep `package.json` and the tag in lockstep. Verify visually before pushing. |
+
+## Troubleshooting
+
+**"Tag v2.0.0 already exists"** — most often happens when a previous `npm version` ran without `--no-git-tag-version`. Delete the stray tag (`git tag -d v2.0.0`, plus `git push --delete origin v2.0.0` if it was pushed) and retry.
+
+**"Working tree is not clean"** — commit or stash everything first. The script will not touch a dirty tree.
+
+**"On branch X, expected main"** — releases cut only from `main`. If you have release-prep work on a branch, merge it via PR first.
+
+**"No changelog entries added under ## X.Y.Z"** — the editor was saved with only the empty `- ` stub. Add bullets and rerun.
+
+**Local main is behind origin/main** — `git pull --ff-only` first, then retry.
+
+**AI drafted weird bullets** — edit them in `$EDITOR` before saving. If `claude` itself is misbehaving, uninstall or unset `PATH` for that run; the script falls back to the empty stub.
+
+## Future improvements (not blockers)
+
+- A `--tag next` dist-tag flag for RCs so `npm publish` doesn't tag them as `latest`.
+- A small CI workflow that mirrors the CHANGELOG section into the GitHub Release body automatically (read-only on the repo, no commit-back).
+- A `release-please`-style PR-driven model if we move to multi-maintainer release ownership.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,42 +4,52 @@ How we cut a release of `llm-testrunner-components`. This document is the single
 
 ## TL;DR
 
-Releases are local-driven:
+Releases are **PR-driven**:
 
-1. Run `npm run release:patch` (or `:minor` / `:major`).
-2. Script bumps the version, drafts the changelog with AI assistance, lets you review in `$EDITOR`, then commits and tags locally.
-3. You push the branch and the tag, then publish to npm.
+1. `git checkout -b release-<your-version>` off `main`. Follow recommended convention for branch naming.
+2. Run `npm run release:patch` (or `:minor` / `:major`).
+3. Script bumps the version, drafts the changelog with AI assistance, lets you review in `$EDITOR`, then commits **on your release branch** (no tag yet).
+4. Push the branch, open a PR to `main`, get it reviewed and merged.
+5. After merge, tag the merge commit on `main` and publish to npm.
 
 There is no auto-publish CI workflow. The `publish.yml` workflow remains as a manual `workflow_dispatch` fallback for hot-publish scenarios.
 
 ## Flow
 
 ```
-npm run release:patch
-  ├─ preflight (clean tree, on main, in sync with origin/main)
+git checkout -b release-2.1.0
+npm run release:minor
+  ├─ preflight (clean tree, NOT on main, origin/main ancestor of HEAD)
   ├─ lint + test + license-check
   ├─ npm version <bump> --no-git-tag-version
   ├─ assert vX.Y.Z tag doesn't already exist
   ├─ Claude CLI drafts CHANGELOG bullets (skipped if `claude` not installed)
   ├─ $EDITOR opens CHANGELOG.md for review
-  ├─ git commit -m "chore(release): X.Y.Z"
-  └─ git tag -a vX.Y.Z -m "vX.Y.Z"
+  └─ git commit -m "chore(release): X.Y.Z"      # on the release branch
 
 # Then, manually:
-git push origin main
-git push origin vX.Y.Z
+git push -u origin release-2.1.0
+gh pr create --base main --title "release: v2.1.0" --body "<changelog section>"
+
+# --- review + merge the PR ---
+
+git checkout main && git pull --ff-only
+git tag -a v2.1.0 -m "v2.1.0"
+git push origin v2.1.0
 npm run build-publish
-gh release create vX.Y.Z --notes "..."   # or use the GitHub UI
+gh release create v2.1.0 --notes "<changelog section>"
 ```
+
+The script prints all of step 2 onward as a copy-paste block at the end of the run.
 
 ## Commands
 
 | Command | Result |
 |---------|--------|
-| `npm run release:patch` | 1.4.0 → 1.4.1 |
-| `npm run release:minor` | 1.4.0 → 1.5.0 |
-| `npm run release:major` | 1.4.0 → 2.0.0 |
-| `npm run release -- 2.0.0-rc.1` | explicit version (RC) |
+| `npm run release:patch` | 2.1.0 → 2.1.1 |
+| `npm run release:minor` | 2.1.0 → 2.2.0 |
+| `npm run release:major` | 2.1.0 → 3.0.0 |
+| `npm run release -- 2.2.0-rc.1` | explicit version (RC) |
 | `npm run release -- minor --dry-run` | preview every command, change nothing |
 | `npm run release -- patch --no-test` | skip lint+test+license-check |
 
@@ -47,54 +57,70 @@ gh release create vX.Y.Z --notes "..."   # or use the GitHub UI
 
 ## What the script enforces
 
-Steps run in order. Any failure aborts the release.
+Steps run in order. Any failure aborts.
 
 1. Working tree is clean.
-2. Current branch is `main`.
-3. Local `main` matches `origin/main`.
+2. Current branch is **not** `main`. Releases must happen on a separate branch so a reviewer sees the version + changelog in a PR.
+3. `origin/main` is an ancestor of `HEAD` (i.e. the release branch is based on current `main`, not stale).
 4. `lint`, `test`, `license-check` all pass (skippable via `--no-test`).
 5. Bumps version via `npm version <arg> --no-git-tag-version`.
 6. Asserts `vX.Y.Z` does not already exist locally or on origin.
 7. Calls Claude CLI with `git log` + `git diff --stat` since the previous `v*` tag. Asks for 3–7 high-level bullets. Falls back to an empty `- ` stub if `claude` is not installed.
 8. Prepends `## X.Y.Z` plus the bullets to `CHANGELOG.md` and opens `$EDITOR`.
 9. After save, verifies the new section actually has content (not just an empty stub).
-10. `git commit -m "chore(release): X.Y.Z"`.
-11. `git tag -a vX.Y.Z -m "vX.Y.Z"`.
-12. Prints the push, `npm run build-publish`, and `gh release create` commands so you can review before handing off.
+10. `git commit -m "chore(release): X.Y.Z"` on the current branch. **No tag.**
+11. Prints the push, PR-creation, post-merge tag, publish, and `gh release create` commands so you can review before handing off.
 
-**Rollback:** if any step between the version bump and the tag fails, the script restores `package.json`, `package-lock.json`, and `CHANGELOG.md` so the next retry starts clean.
+**Rollback:** if any step between the version bump and the commit fails, the script restores `package.json`, `package-lock.json`, and `CHANGELOG.md` so the next retry starts clean.
 
 **AI requirement:** none. If the `claude` CLI is on your PATH, the script uses it. If not, you get an empty stub to fill in by hand.
 
 ## Manual steps after the script
 
-The script stops after the local tag. You drive the rest:
+The script stops after the local commit. You drive the rest:
 
 ```bash
-# 1. Push the branch and the tag
-git push origin main <branch_name>
-git push origin vX.Y.Z
+# 1. Push the release branch
+git push -u origin release-X.Y.Z
 
-# 2. Publish to npm (If you chose to do it locally)
-npm run build-publish
-
-# 3. Create the GitHub Release (mirrors the CHANGELOG section as the body)
-gh release create vX.Y.Z \
-  --title "vX.Y.Z" \
-  --notes "$(awk -v ver=\"X.Y.Z\" '
-    $0 == \"## \" ver { found=1; next }
+# 2. Open a PR to main
+gh pr create --base main \
+  --title "release: vX.Y.Z" \
+  --body "$(awk -v ver='X.Y.Z' '
+    $0 == "## " ver { found=1; next }
     found && /^## / { exit }
     found { print }
   ' CHANGELOG.md)"
+
+# --- review + merge the PR ---
+
+# 3. After PR merges, tag the merge commit on main
+git checkout main && git pull --ff-only
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+
+# 4. Create the GitHub Release (mirrors the CHANGELOG section as the body)
+gh release create vX.Y.Z \
+  --title "vX.Y.Z" \
+  --notes "$(awk -v ver='X.Y.Z' '
+    $0 == "## " ver { found=1; next }
+    found && /^## / { exit }
+    found { print }
+  ' CHANGELOG.md)"
+
+# 5. Publish to npm
+npm run build-publish
 ```
 
-The script prints all three command groups at the end, ready to copy-paste with the correct version filled in.
+The script prints all five command blocks at the end, ready to copy-paste with the correct version filled in.
 
 ## Conventions
 
-- **Tag format:** `vX.Y.Z` (matches the existing `v1.3.5-internal.0` style).
+- **Tag format:** `vX.Y.Z` (matches the existing `v1.3.5-internal.0` style). The tag, not the branch, defines the release.
 - **Release commit:** `chore(release): X.Y.Z` (Conventional Commits).
-- **Branches:** releases cut only from `main`. Feature branches merge to `main` via PR first.
+- **Branch name:** anything that won't collide. `release-X.Y.Z`, `bump-X.Y.Z`, `chore/release-X.Y.Z` all work. Branch is a workspace, not the release artifact.
+- **PR title:** `release: vX.Y.Z` — easy to spot in the PR list.
+- **Branches:** release branches cut from `main`. Script refuses to run on `main` itself.
 - **Pre-releases:** suffix with `-rc.N` (e.g. `2.0.0-rc.1`). Publish these under the `next` dist-tag manually: `npm publish --tag next --access=public` — the script does not branch on this yet.
 - **Migration notes:** for majors, link to the version PR from the corresponding `## X.0.0` section of `CHANGELOG.md`.
 
@@ -102,24 +128,25 @@ The script prints all three command groups at the end, ready to copy-paste with 
 
 | Concern | How we handle it |
 |---------|-----------------|
-| Single source of truth for what shipped | Tag commit contains the matching `CHANGELOG.md` entry. |
-| Avoid "tag updates changelog" chicken-and-egg | Local script does the bump + changelog before tagging. |
-| Branch protection on `main` | No CI ever pushes to `main`. |
+| Single source of truth for what shipped | The tag points at the merge commit, which contains the matching `CHANGELOG.md` entry. |
+| Reviewer sees the version bump + changelog before it lands | Release PR shows the diff. CI runs the full pipeline on the PR. |
+| Branch protection on `main` | Script never touches `main`. Only the merge (via PR) and the tag push go to it. |
 | Cost / API key sprawl | AI runs locally using the developer's existing Claude CLI auth. Zero new GitHub secrets. |
 | Human review of AI output | Script opens `$EDITOR` after AI drafts. You always see the changelog before it's committed. |
-| Wrong version published | Local preflight + `npm version` keep `package.json` and the tag in lockstep. Verify visually before pushing. |
+| Wrong version published | Local preflight + `npm version` keep `package.json` and the tag in lockstep. The PR diff is the second sanity check. |
+| Avoid "tag updates changelog" chicken-and-egg | Changelog is committed BEFORE the tag exists. Tag goes on the merge commit AFTER review. |
 
 ## Troubleshooting
+
+**"On 'main'. Releases must run on a separate branch."** — `git checkout -b release-<your-version>` first, then rerun.
+
+**"origin/main is not an ancestor of HEAD."** — your release branch is based on something other than current `main`. Run `git fetch origin main && git rebase origin/main` (or `git merge origin/main`) and retry.
 
 **"Tag v2.0.0 already exists"** — most often happens when a previous `npm version` ran without `--no-git-tag-version`. Delete the stray tag (`git tag -d v2.0.0`, plus `git push --delete origin v2.0.0` if it was pushed) and retry.
 
 **"Working tree is not clean"** — commit or stash everything first. The script will not touch a dirty tree.
 
-**"On branch X, expected main"** — releases cut only from `main`. If you have release-prep work on a branch, merge it via PR first.
-
 **"No changelog entries added under ## X.Y.Z"** — the editor was saved with only the empty `- ` stub. Add bullets and rerun.
-
-**Local main is behind origin/main** — `git pull --ff-only` first, then retry.
 
 **AI drafted weird bullets** — edit them in `$EDITOR` before saving. If `claude` itself is misbehaving, uninstall or unset `PATH` for that run; the script falls back to the empty stub.
 
@@ -127,4 +154,4 @@ The script prints all three command groups at the end, ready to copy-paste with 
 
 - A `--tag next` dist-tag flag for RCs so `npm publish` doesn't tag them as `latest`.
 - A small CI workflow that mirrors the CHANGELOG section into the GitHub Release body automatically (read-only on the repo, no commit-back).
-- A `release-please`-style PR-driven model if we move to multi-maintainer release ownership.
+- A `release-please`-style fully automated PR-driven model if we move to multi-maintainer release ownership.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,40 +4,34 @@ How we cut a release of `llm-testrunner-components`. This document is the single
 
 ## TL;DR
 
-Releases are **PR-driven**:
+Releases are local-driven from `main`:
 
-1. `git checkout -b release-<your-version>` off `main`. Follow recommended convention for branch naming.
+1. `git checkout main && git pull --ff-only`.
 2. Run `npm run release:patch` (or `:minor` / `:major`).
-3. Script bumps the version, drafts the changelog with AI assistance, lets you review in `$EDITOR`, then commits **on your release branch** (no tag yet).
-4. Push the branch, open a PR to `main`, get it reviewed and merged.
-5. After merge, tag the merge commit on `main` and publish to npm.
+3. Script bumps the version, drafts the changelog with AI assistance, lets you review in `$EDITOR`, then commits and tags locally **on `main`**.
+4. You push the commit + tag, publish to npm, and create the GitHub Release.
 
 There is no auto-publish CI workflow. The `publish.yml` workflow remains as a manual `workflow_dispatch` fallback for hot-publish scenarios.
 
 ## Flow
 
 ```
-git checkout -b release-2.1.0
+git checkout main && git pull --ff-only
 npm run release:minor
-  ├─ preflight (clean tree, NOT on main, origin/main ancestor of HEAD)
+  ├─ preflight (clean tree, on main, in sync with origin/main)
   ├─ lint + test + license-check
   ├─ npm version <bump> --no-git-tag-version
   ├─ assert vX.Y.Z tag doesn't already exist
   ├─ Claude CLI drafts CHANGELOG bullets (skipped if `claude` not installed)
   ├─ $EDITOR opens CHANGELOG.md for review
-  └─ git commit -m "chore(release): X.Y.Z"      # on the release branch
+  ├─ git commit -m "chore(release): X.Y.Z"
+  └─ git tag -a vX.Y.Z -m "vX.Y.Z"
 
 # Then, manually:
-git push -u origin release-2.1.0
-gh pr create --base main --title "release: v2.1.0" --body "<changelog section>"
-
-# --- review + merge the PR ---
-
-git checkout main && git pull --ff-only
-git tag -a v2.1.0 -m "v2.1.0"
-git push origin v2.1.0
+git push origin main
+git push origin vX.Y.Z
 npm run build-publish
-gh release create v2.1.0 --notes "<changelog section>"
+gh release create vX.Y.Z --notes "<changelog section>"
 ```
 
 The script prints all of step 2 onward as a copy-paste block at the end of the run.
@@ -60,46 +54,35 @@ The script prints all of step 2 onward as a copy-paste block at the end of the r
 Steps run in order. Any failure aborts.
 
 1. Working tree is clean.
-2. Current branch is **not** `main`. Releases must happen on a separate branch so a reviewer sees the version + changelog in a PR.
-3. `origin/main` is an ancestor of `HEAD` (i.e. the release branch is based on current `main`, not stale).
+2. Current branch is **`main`**. Releases cut only from `main`.
+3. Local `main` matches `origin/main` exactly (no local drift, no remote drift).
 4. `lint`, `test`, `license-check` all pass (skippable via `--no-test`).
 5. Bumps version via `npm version <arg> --no-git-tag-version`.
 6. Asserts `vX.Y.Z` does not already exist locally or on origin.
 7. Calls Claude CLI with `git log` + `git diff --stat` since the previous `v*` tag. Asks for 3–7 high-level bullets. Falls back to an empty `- ` stub if `claude` is not installed.
 8. Prepends `## X.Y.Z` plus the bullets to `CHANGELOG.md` and opens `$EDITOR`.
 9. After save, verifies the new section actually has content (not just an empty stub).
-10. `git commit -m "chore(release): X.Y.Z"` on the current branch. **No tag.**
-11. Prints the push, PR-creation, post-merge tag, publish, and `gh release create` commands so you can review before handing off.
+10. `git commit -m "chore(release): X.Y.Z"`.
+11. `git tag -a vX.Y.Z -m "vX.Y.Z"`.
+12. Prints the push, publish, and `gh release create` commands so you can review before handing off.
 
-**Rollback:** if any step between the version bump and the commit fails, the script restores `package.json`, `package-lock.json`, and `CHANGELOG.md` so the next retry starts clean.
+**Rollback:** if any step between the version bump and the tag fails, the script restores `package.json`, `package-lock.json`, and `CHANGELOG.md` so the next retry starts clean.
 
 **AI requirement:** none. If the `claude` CLI is on your PATH, the script uses it. If not, you get an empty stub to fill in by hand.
 
 ## Manual steps after the script
 
-The script stops after the local commit. You drive the rest:
+The script stops after the local tag. You drive the rest:
 
 ```bash
-# 1. Push the release branch
-git push -u origin release-X.Y.Z
-
-# 2. Open a PR to main
-gh pr create --base main \
-  --title "release: vX.Y.Z" \
-  --body "$(awk -v ver='X.Y.Z' '
-    $0 == "## " ver { found=1; next }
-    found && /^## / { exit }
-    found { print }
-  ' CHANGELOG.md)"
-
-# --- review + merge the PR ---
-
-# 3. After PR merges, tag the merge commit on main
-git checkout main && git pull --ff-only
-git tag -a vX.Y.Z -m "vX.Y.Z"
+# 1. Push the release commit + tag
+git push origin main
 git push origin vX.Y.Z
 
-# 4. Create the GitHub Release (mirrors the CHANGELOG section as the body)
+# 2. Publish to npm
+npm run build-publish
+
+# 3. Create the GitHub Release (mirrors the CHANGELOG section as the body)
 gh release create vX.Y.Z \
   --title "vX.Y.Z" \
   --notes "$(awk -v ver='X.Y.Z' '
@@ -107,20 +90,15 @@ gh release create vX.Y.Z \
     found && /^## / { exit }
     found { print }
   ' CHANGELOG.md)"
-
-# 5. Publish to npm
-npm run build-publish
 ```
 
-The script prints all five command blocks at the end, ready to copy-paste with the correct version filled in.
+The script prints all three command blocks at the end, ready to copy-paste with the correct version filled in.
 
 ## Conventions
 
-- **Tag format:** `vX.Y.Z` (matches the existing `v1.3.5-internal.0` style). The tag, not the branch, defines the release.
+- **Tag format:** `vX.Y.Z` (matches the existing `v1.3.5-internal.0` style).
 - **Release commit:** `chore(release): X.Y.Z` (Conventional Commits).
-- **Branch name:** anything that won't collide. `release-X.Y.Z`, `bump-X.Y.Z`, `chore/release-X.Y.Z` all work. Branch is a workspace, not the release artifact.
-- **PR title:** `release: vX.Y.Z` — easy to spot in the PR list.
-- **Branches:** release branches cut from `main`. Script refuses to run on `main` itself.
+- **Branches:** releases cut only from `main`. Feature branches merge to `main` via PR first.
 - **Pre-releases:** suffix with `-rc.N` (e.g. `2.0.0-rc.1`). Publish these under the `next` dist-tag manually: `npm publish --tag next --access=public` — the script does not branch on this yet.
 - **Migration notes:** for majors, link to the version PR from the corresponding `## X.0.0` section of `CHANGELOG.md`.
 
@@ -128,19 +106,18 @@ The script prints all five command blocks at the end, ready to copy-paste with t
 
 | Concern | How we handle it |
 |---------|-----------------|
-| Single source of truth for what shipped | The tag points at the merge commit, which contains the matching `CHANGELOG.md` entry. |
-| Reviewer sees the version bump + changelog before it lands | Release PR shows the diff. CI runs the full pipeline on the PR. |
-| Branch protection on `main` | Script never touches `main`. Only the merge (via PR) and the tag push go to it. |
+| Single source of truth for what shipped | Tag commit contains the matching `CHANGELOG.md` entry. |
+| Avoid "tag updates changelog" chicken-and-egg | Local script does the bump + changelog before tagging. |
+| Branch protection on `main` | No CI ever pushes to `main` — only the local script's authenticated push does. |
 | Cost / API key sprawl | AI runs locally using the developer's existing Claude CLI auth. Zero new GitHub secrets. |
 | Human review of AI output | Script opens `$EDITOR` after AI drafts. You always see the changelog before it's committed. |
-| Wrong version published | Local preflight + `npm version` keep `package.json` and the tag in lockstep. The PR diff is the second sanity check. |
-| Avoid "tag updates changelog" chicken-and-egg | Changelog is committed BEFORE the tag exists. Tag goes on the merge commit AFTER review. |
+| Wrong version published | Local preflight + `npm version` keep `package.json` and the tag in lockstep. Verify visually before pushing. |
 
 ## Troubleshooting
 
-**"On 'main'. Releases must run on a separate branch."** — `git checkout -b release-<your-version>` first, then rerun.
+**"On 'X', expected 'main'."** — `git checkout main && git pull --ff-only` first, then rerun.
 
-**"origin/main is not an ancestor of HEAD."** — your release branch is based on something other than current `main`. Run `git fetch origin main && git rebase origin/main` (or `git merge origin/main`) and retry.
+**"Local main not in sync with origin/main."** — `git pull --ff-only` (or `git push origin main`) to sync, then rerun.
 
 **"Tag v2.0.0 already exists"** — most often happens when a previous `npm version` ran without `--no-git-tag-version`. Delete the stray tag (`git tag -d v2.0.0`, plus `git push --delete origin v2.0.0` if it was pushed) and retry.
 
@@ -154,4 +131,4 @@ The script prints all five command blocks at the end, ready to copy-paste with t
 
 - A `--tag next` dist-tag flag for RCs so `npm publish` doesn't tag them as `latest`.
 - A small CI workflow that mirrors the CHANGELOG section into the GitHub Release body automatically (read-only on the repo, no commit-back).
-- A `release-please`-style fully automated PR-driven model if we move to multi-maintainer release ownership.
+- A `release-please`-style PR-driven model if we ever need multi-maintainer release ownership.

--- a/package.json
+++ b/package.json
@@ -73,7 +73,11 @@
     "just-publish": "npm publish --access=public",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint src --ext .ts,.tsx --fix",
-    "license-check": "licensee"
+    "license-check": "licensee",
+    "release": "bash scripts/release.sh",
+    "release:patch": "bash scripts/release.sh patch",
+    "release:minor": "bash scripts/release.sh minor",
+    "release:major": "bash scripts/release.sh major"
   },
   "dependencies": {
     "@google/genai": "^1.40.0",

--- a/scripts/release-prompt.md
+++ b/scripts/release-prompt.md
@@ -1,0 +1,54 @@
+As a Project Manager you are drafting a CHANGELOG entry for version {{VERSION}} of the npm package {{PACKAGE_NAME}}.
+
+Write 3-7 high-level bullet points summarizing the changes below.
+
+=== WORKED EXAMPLE ===
+
+GIVEN commits like:
+  feat(summary): add pass-rate dashboard component
+  feat(summary): show Show summary checkbox in header
+  feat(summary): animated number transitions on chip counts
+  feat(llm-judge): wire end-to-end evaluation
+  feat(llm-judge): support system + user prompts
+  feat(llm-judge): return per-criterion scores
+  feat(status): introduce 'evaluating' and 'partial' kinds
+  refactor(row): redesign test case row layout
+  refactor(header): consolidate import/export/save controls
+  fix(row): clear flicker between LLM response and evaluation
+  chore: bump ws from 8.19.0 to 8.20.1
+  chore: update eslint config
+
+AND diff stat showing changes in:
+  src/components/llm-test-runner/summary/*
+  src/components/llm-test-runner/header/*
+  src/components/llm-test-runner/test-cases/*
+  src/lib/evaluation/evaluators/llm-judge/*
+
+EXPECTED output:
+- New summary dashboard
+- Test-runner UI redesigned
+- LLM-as-judge evaluation approach
+- Richer test status states
+
+Notice:
+- chore commits (dependency bumps, lint config) are dropped — not user-facing.
+- 4 related "summary" commits collapsed into one bullet.
+- 3 related "llm-judge" commits collapsed into one bullet.
+- 2 refactor commits about layout collapsed into "Test-runner UI redesigned".
+- The fix is internal mechanics, not surfaced — release note focuses on what users see.
+
+=== STRICT RULES ===
+
+- Output ONLY bullet lines (each starts with "- ").
+- No headings, no preamble, no commentary, no commit hashes, no PR numbers, no emojis.
+- One line per bullet.
+- Group related commits aggressively. One bullet can summarize 3-10 commits.
+- Drop chore / dependency-bump / lint / formatting / internal commits unless notable (security CVE = notable).
+- Prefer user-facing impact over internal mechanics.
+- Match the terse style of the EXPECTED output above — short noun phrases, no fluff.
+
+=== Commits since {{PREV_TAG}} ===
+{{COMMITS}}
+
+=== Files changed ===
+{{DIFFSTAT}}

--- a/scripts/release-prompt.md
+++ b/scripts/release-prompt.md
@@ -1,6 +1,17 @@
 As a Project Manager you are drafting a CHANGELOG entry for version {{VERSION}} of the npm package {{PACKAGE_NAME}}.
 
-Write 3-7 high-level bullet points summarizing the changes below.
+The CHANGELOG follows a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)-inspired format with custom section names and icons. Each version section uses `###` subheadings to group changes by type.
+
+Allowed section headings (use them VERBATIM, including the emoji and the space after it):
+
+- `### 🚀 What's new` — new features, new APIs, new capabilities (was `### Added` in standard Keep a Changelog)
+- `### 🔧 Changed` — changes to existing functionality
+- `### ⚠️ Deprecated` — soon-to-be-removed features
+- `### 🗑️ Removed` — features removed in this release
+- `### 🐛 Fixed` — bug fixes
+- `### 🔒 Security` — security-related changes
+
+Only include sections that have at least one entry. Skip empty sections.
 
 === WORKED EXAMPLE ===
 
@@ -25,25 +36,39 @@ AND diff stat showing changes in:
   src/lib/evaluation/evaluators/llm-judge/*
 
 EXPECTED output:
+
+### 🚀 What's new
+
 - New summary dashboard
-- Test-runner UI redesigned
 - LLM-as-judge evaluation approach
-- Richer test status states
+- Richer test status states (evaluating, partial)
+
+### 🔧 Changed
+
+- Test-runner UI redesigned
+
+### 🐛 Fixed
+
+- Status flicker between LLM response and evaluation
 
 Notice:
+
 - chore commits (dependency bumps, lint config) are dropped — not user-facing.
-- 4 related "summary" commits collapsed into one bullet.
-- 3 related "llm-judge" commits collapsed into one bullet.
-- 2 refactor commits about layout collapsed into "Test-runner UI redesigned".
-- The fix is internal mechanics, not surfaced — release note focuses on what users see.
+- 3 related "summary" commits collapsed into one What's new bullet.
+- 3 related "llm-judge" commits collapsed into one What's new bullet.
+- 2 refactor commits about layout collapsed into "Test-runner UI redesigned" under Changed.
+- The fix is surfaced under Fixed (it was user-visible flicker).
 
 === STRICT RULES ===
 
-- Output ONLY bullet lines (each starts with "- ").
-- No headings, no preamble, no commentary, no commit hashes, no PR numbers, no emojis.
+- Output ONLY the `### <icon> Section` headings and `- ` bullet lines, with blank lines between sections.
+- Use the section headings VERBATIM from the list above. Do not change icons, drop them, or invent new ones.
+- No top-level heading (the `## VERSION` line is added by the script).
+- No preamble, no commentary, no commit hashes, no PR numbers.
+- No emojis inside bullet text — emojis live only on the section headings.
 - One line per bullet.
 - Group related commits aggressively. One bullet can summarize 3-10 commits.
-- Drop chore / dependency-bump / lint / formatting / internal commits unless notable (security CVE = notable).
+- Drop chore / dependency-bump / lint / formatting / internal commits unless notable (security CVE = notable → under `### 🔒 Security`).
 - Prefer user-facing impact over internal mechanics.
 - Match the terse style of the EXPECTED output above — short noun phrases, no fluff.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# release.sh — version bump + changelog + commit + tag (local only).
+# release.sh — prep a release PR locally (Pattern Y: PR-driven release).
 #
 # Usage:
+#   git checkout -b release-<your-version>
 #   scripts/release.sh <major|minor|patch|prerelease|X.Y.Z[-rc.N]> [--dry-run] [--no-test]
 #
 # Examples:
@@ -10,17 +11,22 @@
 #   scripts/release.sh 2.1.0-rc.1
 #   scripts/release.sh major --no-test       # only if CI already ran the suite
 #
-# What it does:
-#   1. Asserts clean tree, on `main`, in sync with origin.
+# What it does (Pattern Y — release PR flow):
+#   1. Asserts clean tree, NOT on `main`, and that origin/main is reachable from HEAD.
 #   2. Asserts the resulting tag does not already exist (local + remote).
 #   3. Runs lint + test + license-check (skippable with --no-test).
 #   4. Bumps version via `npm version <arg> --no-git-tag-version`.
-#   5. Prepends a stub section to CHANGELOG.md and opens $EDITOR for you to fill in.
-#   6. Validates bullets were added.
-#   7. Commits `chore(release): X.Y.Z` and tags `vX.Y.Z`.
-#   8. Prints the manual push/release commands to run next.
+#   5. AI-drafts changelog bullets (if `claude` CLI available); falls back to empty stub.
+#   6. Opens $EDITOR on CHANGELOG.md for review.
+#   7. Validates bullets were added.
+#   8. Commits `chore(release): X.Y.Z` on the current branch (NO tag).
+#   9. Prints the push + PR-creation + post-merge tag + publish commands.
 #
-# Any failure between step 4 and step 7 rolls back package.json,
+# The tag is NOT created by this script — it goes on the merge commit AFTER
+# the PR is approved and merged into `main`. The release artifact is the
+# tag, not the branch; branch name is purely cosmetic.
+#
+# Any failure between step 4 and step 8 rolls back package.json,
 # package-lock.json, and CHANGELOG.md so retries start clean.
 
 set -euo pipefail
@@ -41,7 +47,7 @@ die()   { printf '%s✗%s   %s\n' "$RED"    "$RESET" "$*" >&2; exit 1; }
 BUMP=""
 DRY_RUN=0
 SKIP_TEST=0
-EXPECTED_BRANCH="main"
+PROTECTED_BRANCH="main"   # the branch we release INTO (script refuses to run on it)
 
 for arg in "$@"; do
   case "$arg" in
@@ -89,22 +95,31 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
 fi
 ok "Working tree clean"
 
-# On expected branch
+# Refuse to run on the protected branch — releases happen on a dedicated branch
+# and merge to $PROTECTED_BRANCH via PR. The merge commit is what gets tagged.
 CUR_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$CUR_BRANCH" != "$EXPECTED_BRANCH" ]; then
-  die "On '$CUR_BRANCH', expected '$EXPECTED_BRANCH'. Releases must cut from $EXPECTED_BRANCH."
+if [ "$CUR_BRANCH" = "$PROTECTED_BRANCH" ]; then
+  die "On '$PROTECTED_BRANCH'. Releases must run on a separate branch.
+       Run:
+         git checkout -b release-<your-version>
+         npm run release:<bump>
+       The branch name itself is up to you — it's just a workspace for the
+       release PR. The tag, not the branch, defines the release."
 fi
-ok "On branch $EXPECTED_BRANCH"
+ok "On branch '$CUR_BRANCH' (not '$PROTECTED_BRANCH')"
 
-# In sync with origin
+# Make sure $PROTECTED_BRANCH is reachable from HEAD — i.e. this branch is
+# based on (or ahead of) $PROTECTED_BRANCH. Catches the case where someone
+# branched from an old commit and is about to release stale code.
 info "Fetching origin..."
 run git fetch origin --quiet
-LOCAL=$(git rev-parse HEAD)
-REMOTE=$(git rev-parse "origin/$EXPECTED_BRANCH")
-if [ "$LOCAL" != "$REMOTE" ]; then
-  die "Local $EXPECTED_BRANCH not in sync with origin/$EXPECTED_BRANCH. Pull or push first."
+if [ "$DRY_RUN" -eq 0 ]; then
+  if ! git merge-base --is-ancestor "origin/$PROTECTED_BRANCH" HEAD; then
+    die "origin/$PROTECTED_BRANCH is not an ancestor of HEAD.
+         Rebase or merge $PROTECTED_BRANCH into '$CUR_BRANCH' first."
+  fi
 fi
-ok "In sync with origin/$EXPECTED_BRANCH"
+ok "Branch is up-to-date with origin/$PROTECTED_BRANCH"
 
 # package.json exists
 [ -f package.json ] || die "No package.json at repo root."
@@ -190,17 +205,52 @@ get_ai_bullets() {
   prompt=$(cat <<EOF
 As a Project Manager you are drafting a CHANGELOG entry for version $NEW_VERSION of the npm package $pkg_name.
 
-Write 3-7 high-level bullet points summarizing the changes below. Match this terse style exactly:
+Write 3-7 high-level bullet points summarizing the changes below.
+
+=== WORKED EXAMPLE ===
+
+GIVEN commits like:
+  feat(summary): add pass-rate dashboard component
+  feat(summary): show Show summary checkbox in header
+  feat(summary): animated number transitions on chip counts
+  feat(llm-judge): wire end-to-end evaluation
+  feat(llm-judge): support system + user prompts
+  feat(llm-judge): return per-criterion scores
+  feat(status): introduce 'evaluating' and 'partial' kinds
+  refactor(row): redesign test case row layout
+  refactor(header): consolidate import/export/save controls
+  fix(row): clear flicker between LLM response and evaluation
+  chore: bump ws from 8.19.0 to 8.20.1
+  chore: update eslint config
+
+AND diff stat showing changes in:
+  src/components/llm-test-runner/summary/*
+  src/components/llm-test-runner/header/*
+  src/components/llm-test-runner/test-cases/*
+  src/lib/evaluation/evaluators/llm-judge/*
+
+EXPECTED output:
 - New summary dashboard
 - Test-runner UI redesigned
 - LLM-as-judge evaluation approach
+- Richer test status states
 
-Strict rules:
+Notice:
+- chore commits (dependency bumps, lint config) are dropped — not user-facing.
+- 4 related "summary" commits collapsed into one bullet.
+- 3 related "llm-judge" commits collapsed into one bullet.
+- 2 refactor commits about layout collapsed into "Test-runner UI redesigned".
+- The fix is internal mechanics, not surfaced — release note focuses on what users see.
+
+=== STRICT RULES ===
+
 - Output ONLY bullet lines (each starts with "- ").
 - No headings, no preamble, no commentary, no commit hashes, no PR numbers, no emojis.
 - One line per bullet.
-- Group related commits. Drop chore/dependency-bump/internal commits unless notable.
+- Group related commits aggressively. One bullet can summarize 3-10 commits.
+- Drop chore / dependency-bump / lint / formatting / internal commits unless notable (security CVE = notable).
 - Prefer user-facing impact over internal mechanics.
+- Match the terse style of the EXPECTED output above — short noun phrases, no fluff.
 
 === Commits since ${prev_tag:-HEAD} ===
 $commits
@@ -279,27 +329,39 @@ if [ "$DRY_RUN" -eq 0 ]; then
   ok "Changelog entries detected"
 fi
 
-# ---------- commit + tag ----------
-info "Committing release"
+# ---------- commit (no tag — tag happens after PR merge) ----------
+info "Committing release on '$CUR_BRANCH'"
 run git add package.json package-lock.json CHANGELOG.md
 run git commit -m "chore(release): $NEW_VERSION"
 
-info "Tagging $TAG"
-run git tag -a "$TAG" -m "$TAG"
-
 ROLLBACK_NEEDED=0
-ok "Release $NEW_VERSION ready locally."
+ok "Release commit for $NEW_VERSION ready on '$CUR_BRANCH'."
 
 # ---------- next steps ----------
 cat <<EOF
 
 ${BOLD}Next steps (run manually when ready):${RESET}
 
-  ${BLUE}# push branch and tag${RESET}
-  git push origin $EXPECTED_BRANCH
+  ${BLUE}# 1. Push the release branch${RESET}
+  git push -u origin $CUR_BRANCH
+
+  ${BLUE}# 2. Open a PR to $PROTECTED_BRANCH (gh CLI)${RESET}
+  gh pr create --base $PROTECTED_BRANCH \\
+    --title "release: $TAG" \\
+    --body "\$(awk -v ver=\"$NEW_VERSION\" '
+      \$0 == \"## \" ver { found=1; next }
+      found && /^## / { exit }
+      found { print }
+    ' CHANGELOG.md)"
+
+  ${YELLOW}# --- review + merge the PR before running the rest ---${RESET}
+
+  ${BLUE}# 3. After PR merges, tag the merge commit on $PROTECTED_BRANCH${RESET}
+  git checkout $PROTECTED_BRANCH && git pull --ff-only
+  git tag -a $TAG -m "$TAG"
   git push origin $TAG
 
-  ${BLUE}# create GitHub Release (requires gh CLI)${RESET}
+  ${BLUE}# 4. Create GitHub Release${RESET}
   gh release create $TAG \\
     --title "$TAG" \\
     --notes "\$(awk -v ver=\"$NEW_VERSION\" '
@@ -308,7 +370,7 @@ ${BOLD}Next steps (run manually when ready):${RESET}
       found { print }
     ' CHANGELOG.md)"
 
-  ${BLUE}# publish to npm${RESET}
+  ${BLUE}# 5. Publish to npm${RESET}
   npm run build-publish
 
 EOF

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-# release.sh — prep a release PR locally (Pattern Y: PR-driven release).
+# release.sh — version bump + changelog + commit + tag (local only).
 #
 # Usage:
-#   git checkout -b release-<your-version>
 #   scripts/release.sh <major|minor|patch|prerelease|X.Y.Z[-rc.N]> [--dry-run] [--no-test]
 #
 # Examples:
@@ -11,22 +10,19 @@
 #   scripts/release.sh 2.1.0-rc.1
 #   scripts/release.sh major --no-test       # only if CI already ran the suite
 #
-# What it does (Pattern Y — release PR flow):
-#   1. Asserts clean tree, NOT on `main`, and that origin/main is reachable from HEAD.
+# What it does:
+#   1. Asserts clean tree, on `main`, in sync with origin/main.
 #   2. Asserts the resulting tag does not already exist (local + remote).
 #   3. Runs lint + test + license-check (skippable with --no-test).
 #   4. Bumps version via `npm version <arg> --no-git-tag-version`.
 #   5. AI-drafts changelog bullets (if `claude` CLI available); falls back to empty stub.
 #   6. Opens $EDITOR on CHANGELOG.md for review.
 #   7. Validates bullets were added.
-#   8. Commits `chore(release): X.Y.Z` on the current branch (NO tag).
-#   9. Prints the push + PR-creation + post-merge tag + publish commands.
+#   8. Commits `chore(release): X.Y.Z` on `main`.
+#   9. Tags `vX.Y.Z` on the commit.
+#  10. Prints the push + publish + GitHub Release commands.
 #
-# The tag is NOT created by this script — it goes on the merge commit AFTER
-# the PR is approved and merged into `main`. The release artifact is the
-# tag, not the branch; branch name is purely cosmetic.
-#
-# Any failure between step 4 and step 8 rolls back package.json,
+# Any failure between step 4 and step 9 rolls back package.json,
 # package-lock.json, and CHANGELOG.md so retries start clean.
 
 set -euo pipefail
@@ -47,7 +43,7 @@ die()   { printf '%s✗%s   %s\n' "$RED"    "$RESET" "$*" >&2; exit 1; }
 BUMP=""
 DRY_RUN=0
 SKIP_TEST=0
-PROTECTED_BRANCH="main"   # the branch we release INTO (script refuses to run on it)
+EXPECTED_BRANCH="main"   # releases must cut from this branch
 
 for arg in "$@"; do
   case "$arg" in
@@ -95,31 +91,28 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
 fi
 ok "Working tree clean"
 
-# Refuse to run on the protected branch — releases happen on a dedicated branch
-# and merge to $PROTECTED_BRANCH via PR. The merge commit is what gets tagged.
+# Must be on the expected release branch.
 CUR_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$CUR_BRANCH" = "$PROTECTED_BRANCH" ]; then
-  die "On '$PROTECTED_BRANCH'. Releases must run on a separate branch.
+if [ "$CUR_BRANCH" != "$EXPECTED_BRANCH" ]; then
+  die "On '$CUR_BRANCH', expected '$EXPECTED_BRANCH'. Releases must cut from $EXPECTED_BRANCH.
        Run:
-         git checkout -b release-<your-version>
-         npm run release:<bump>
-       The branch name itself is up to you — it's just a workspace for the
-       release PR. The tag, not the branch, defines the release."
+         git checkout $EXPECTED_BRANCH
+         git pull --ff-only
+         npm run release:<bump>"
 fi
-ok "On branch '$CUR_BRANCH' (not '$PROTECTED_BRANCH')"
+ok "On branch $EXPECTED_BRANCH"
 
-# Make sure $PROTECTED_BRANCH is reachable from HEAD — i.e. this branch is
-# based on (or ahead of) $PROTECTED_BRANCH. Catches the case where someone
-# branched from an old commit and is about to release stale code.
+# Must be in sync with origin/main — no local drift, no remote drift.
 info "Fetching origin..."
 run git fetch origin --quiet
 if [ "$DRY_RUN" -eq 0 ]; then
-  if ! git merge-base --is-ancestor "origin/$PROTECTED_BRANCH" HEAD; then
-    die "origin/$PROTECTED_BRANCH is not an ancestor of HEAD.
-         Rebase or merge $PROTECTED_BRANCH into '$CUR_BRANCH' first."
+  LOCAL=$(git rev-parse HEAD)
+  REMOTE=$(git rev-parse "origin/$EXPECTED_BRANCH")
+  if [ "$LOCAL" != "$REMOTE" ]; then
+    die "Local $EXPECTED_BRANCH not in sync with origin/$EXPECTED_BRANCH. Pull or push first."
   fi
 fi
-ok "Branch is up-to-date with origin/$PROTECTED_BRANCH"
+ok "In sync with origin/$EXPECTED_BRANCH"
 
 # package.json exists
 [ -f package.json ] || die "No package.json at repo root."
@@ -287,39 +280,30 @@ if [ "$DRY_RUN" -eq 0 ]; then
   ok "Changelog entries detected"
 fi
 
-# ---------- commit (no tag — tag happens after PR merge) ----------
-info "Committing release on '$CUR_BRANCH'"
+# ---------- commit + tag ----------
+info "Committing release"
 run git add package.json package-lock.json CHANGELOG.md
 run git commit -m "chore(release): $NEW_VERSION"
 
+info "Tagging $TAG"
+run git tag -a "$TAG" -m "$TAG"
+
 ROLLBACK_NEEDED=0
-ok "Release commit for $NEW_VERSION ready on '$CUR_BRANCH'."
+ok "Release $NEW_VERSION ready locally."
 
 # ---------- next steps ----------
 cat <<EOF
 
 ${BOLD}Next steps (run manually when ready):${RESET}
 
-  ${BLUE}# 1. Push the release branch${RESET}
-  git push -u origin $CUR_BRANCH
-
-  ${BLUE}# 2. Open a PR to $PROTECTED_BRANCH (gh CLI)${RESET}
-  gh pr create --base $PROTECTED_BRANCH \\
-    --title "release: $TAG" \\
-    --body "\$(awk -v ver=\"$NEW_VERSION\" '
-      \$0 == \"## \" ver { found=1; next }
-      found && /^## / { exit }
-      found { print }
-    ' CHANGELOG.md)"
-
-  ${YELLOW}# --- review + merge the PR before running the rest ---${RESET}
-
-  ${BLUE}# 3. After PR merges, tag the merge commit on $PROTECTED_BRANCH${RESET}
-  git checkout $PROTECTED_BRANCH && git pull --ff-only
-  git tag -a $TAG -m "$TAG"
+  ${BLUE}# 1. Push the release commit + tag${RESET}
+  git push origin $EXPECTED_BRANCH
   git push origin $TAG
 
-  ${BLUE}# 4. Create GitHub Release${RESET}
+  ${BLUE}# 2. Publish to npm${RESET}
+  npm run build-publish
+
+  ${BLUE}# 3. Create GitHub Release (mirrors CHANGELOG section as the body)${RESET}
   gh release create $TAG \\
     --title "$TAG" \\
     --notes "\$(awk -v ver=\"$NEW_VERSION\" '
@@ -327,8 +311,5 @@ ${BOLD}Next steps (run manually when ready):${RESET}
       found && /^## / { exit }
       found { print }
     ' CHANGELOG.md)"
-
-  ${BLUE}# 5. Publish to npm${RESET}
-  npm run build-publish
 
 EOF

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# release.sh — version bump + changelog + commit + tag (local only).
+#
+# Usage:
+#   scripts/release.sh <major|minor|patch|prerelease|X.Y.Z[-rc.N]> [--dry-run] [--no-test]
+#
+# Examples:
+#   scripts/release.sh patch
+#   scripts/release.sh minor --dry-run
+#   scripts/release.sh 2.1.0-rc.1
+#   scripts/release.sh major --no-test       # only if CI already ran the suite
+#
+# What it does:
+#   1. Asserts clean tree, on `main`, in sync with origin.
+#   2. Asserts the resulting tag does not already exist (local + remote).
+#   3. Runs lint + test + license-check (skippable with --no-test).
+#   4. Bumps version via `npm version <arg> --no-git-tag-version`.
+#   5. Prepends a stub section to CHANGELOG.md and opens $EDITOR for you to fill in.
+#   6. Validates bullets were added.
+#   7. Commits `chore(release): X.Y.Z` and tags `vX.Y.Z`.
+#   8. Prints the manual push/release commands to run next.
+#
+# Any failure between step 4 and step 7 rolls back package.json,
+# package-lock.json, and CHANGELOG.md so retries start clean.
+
+set -euo pipefail
+
+# ---------- styling ----------
+if [ -t 1 ]; then
+  RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; BLUE=$'\033[34m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BLUE=''; BOLD=''; RESET=''
+fi
+
+info()  { printf '%s==>%s %s\n' "$BLUE"   "$RESET" "$*"; }
+ok()    { printf '%s✓%s   %s\n' "$GREEN"  "$RESET" "$*"; }
+warn()  { printf '%s!%s   %s\n' "$YELLOW" "$RESET" "$*" >&2; }
+die()   { printf '%s✗%s   %s\n' "$RED"    "$RESET" "$*" >&2; exit 1; }
+
+# ---------- arg parsing ----------
+BUMP=""
+DRY_RUN=0
+SKIP_TEST=0
+EXPECTED_BRANCH="main"
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --no-test) SKIP_TEST=1 ;;
+    -h|--help)
+      sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//' | sed '$d'
+      exit 0 ;;
+    -*) die "Unknown flag: $arg" ;;
+    *)  [ -z "$BUMP" ] || die "Multiple bump args: '$BUMP' and '$arg'"
+        BUMP="$arg" ;;
+  esac
+done
+
+[ -n "$BUMP" ] || die "Missing bump arg. See: $0 --help"
+
+# ---------- helpers ----------
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '%s[DRY-RUN]%s %s\n' "$YELLOW" "$RESET" "$*"
+  else
+    "$@"
+  fi
+}
+
+ROLLBACK_NEEDED=0
+rollback() {
+  if [ "$ROLLBACK_NEEDED" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
+    warn "Rolling back package.json, package-lock.json, CHANGELOG.md..."
+    git checkout -- package.json package-lock.json CHANGELOG.md 2>/dev/null || true
+  fi
+}
+trap rollback EXIT
+
+# ---------- locate repo root ----------
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || die "Not inside a git repo."
+cd "$REPO_ROOT"
+
+# ---------- preflight ----------
+info "Preflight checks"
+
+# Clean working tree
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  die "Working tree is not clean. Commit or stash first."
+fi
+ok "Working tree clean"
+
+# On expected branch
+CUR_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CUR_BRANCH" != "$EXPECTED_BRANCH" ]; then
+  die "On '$CUR_BRANCH', expected '$EXPECTED_BRANCH'. Releases must cut from $EXPECTED_BRANCH."
+fi
+ok "On branch $EXPECTED_BRANCH"
+
+# In sync with origin
+info "Fetching origin..."
+run git fetch origin --quiet
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse "origin/$EXPECTED_BRANCH")
+if [ "$LOCAL" != "$REMOTE" ]; then
+  die "Local $EXPECTED_BRANCH not in sync with origin/$EXPECTED_BRANCH. Pull or push first."
+fi
+ok "In sync with origin/$EXPECTED_BRANCH"
+
+# package.json exists
+[ -f package.json ] || die "No package.json at repo root."
+
+# CHANGELOG.md exists (create stub if not)
+if [ ! -f CHANGELOG.md ]; then
+  warn "CHANGELOG.md not found, creating one."
+  printf '# Changelog\n\n' > CHANGELOG.md
+fi
+
+# ---------- tests ----------
+if [ "$SKIP_TEST" -eq 1 ]; then
+  warn "Skipping lint/test/license-check (--no-test). Make sure CI already verified."
+else
+  info "Running lint..."
+  run npm run lint
+  info "Running tests..."
+  run npm run test
+  info "Running license-check..."
+  run npm run license-check
+  ok "All checks passed"
+fi
+
+# ---------- version bump ----------
+info "Bumping version: $BUMP"
+if [ "$DRY_RUN" -eq 1 ]; then
+  CUR_VER=$(node -p "require('./package.json').version")
+  printf '%s[DRY-RUN]%s npm version %s --no-git-tag-version (current: %s)\n' "$YELLOW" "$RESET" "$BUMP" "$CUR_VER"
+  # Compute the resulting version via the `semver` package (available transitively).
+  # Falls back to passing the arg through verbatim if it's an explicit version
+  # like "2.0.0-rc.1" rather than a bump keyword.
+  NEW_VERSION=$(node -e "
+    try {
+      const semver = require('semver');
+      const cur = require('./package.json').version;
+      const bumped = semver.inc(cur, process.argv[1]);
+      console.log(bumped || process.argv[1]);
+    } catch (_) {
+      console.log(process.argv[1]);
+    }
+  " "$BUMP")
+else
+  npm version "$BUMP" --no-git-tag-version >/dev/null
+  ROLLBACK_NEEDED=1
+  NEW_VERSION=$(node -p "require('./package.json').version")
+fi
+ok "New version: $NEW_VERSION"
+
+# Tag must not already exist
+TAG="v$NEW_VERSION"
+if [ "$DRY_RUN" -eq 0 ]; then
+  if git rev-parse "$TAG" >/dev/null 2>&1; then
+    die "Tag $TAG already exists locally."
+  fi
+  if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+    die "Tag $TAG already exists on origin."
+  fi
+  ok "Tag $TAG is free"
+fi
+
+# ---------- AI-drafted bullets (optional) ----------
+# Uses the `claude` CLI if available. Feeds it commit subjects + bodies +
+# diff --stat between the previous v* tag and HEAD, asks for 3-7 short
+# high-level bullets, and uses them to pre-fill the stub. Falls back to
+# an empty "- " stub if `claude` is missing or returns nothing.
+get_ai_bullets() {
+  command -v claude >/dev/null 2>&1 || return 1
+
+  local prev_tag commits diffstat pkg_name prompt output bullets
+  prev_tag=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || true)
+  pkg_name=$(node -p "require('./package.json').name")
+
+  if [ -n "$prev_tag" ]; then
+    commits=$(git log --pretty=format:"%s%n%b%n---" "$prev_tag..HEAD" | head -c 60000)
+    diffstat=$(git diff --stat "$prev_tag..HEAD" | head -c 10000)
+  else
+    commits=$(git log --pretty=format:"%s%n%b%n---" -n 50 | head -c 60000)
+    diffstat=""
+  fi
+
+  [ -n "$commits" ] || return 1
+
+  prompt=$(cat <<EOF
+As a Project Manager you are drafting a CHANGELOG entry for version $NEW_VERSION of the npm package $pkg_name.
+
+Write 3-7 high-level bullet points summarizing the changes below. Match this terse style exactly:
+- New summary dashboard
+- Test-runner UI redesigned
+- LLM-as-judge evaluation approach
+
+Strict rules:
+- Output ONLY bullet lines (each starts with "- ").
+- No headings, no preamble, no commentary, no commit hashes, no PR numbers, no emojis.
+- One line per bullet.
+- Group related commits. Drop chore/dependency-bump/internal commits unless notable.
+- Prefer user-facing impact over internal mechanics.
+
+=== Commits since ${prev_tag:-HEAD} ===
+$commits
+
+=== Files changed ===
+$diffstat
+EOF
+)
+
+  output=$(claude --print "$prompt" 2>/dev/null) || return 1
+  bullets=$(printf '%s\n' "$output" | grep -E '^- ' || true)
+  [ -n "$bullets" ] || return 1
+
+  printf '%s\n' "$bullets"
+}
+
+AI_BULLETS=""
+if [ "$DRY_RUN" -eq 0 ]; then
+  info "Drafting changelog bullets via Claude CLI (optional)..."
+  if AI_BULLETS=$(get_ai_bullets); then
+    ok "AI drafted $(printf '%s' "$AI_BULLETS" | grep -c '^- ') bullets"
+  else
+    warn "Claude CLI unavailable or returned nothing — using empty stub."
+    AI_BULLETS=""
+  fi
+fi
+
+# ---------- changelog ----------
+info "Prepending stub to CHANGELOG.md"
+if [ "$DRY_RUN" -eq 0 ]; then
+  # Build the new section in a temp file so multi-line AI bullets insert cleanly.
+  NEW_SECTION_FILE=$(mktemp)
+  {
+    echo "## $NEW_VERSION"
+    echo ""
+    if [ -n "$AI_BULLETS" ]; then
+      printf '%s\n' "$AI_BULLETS"
+    else
+      echo "- "
+    fi
+    echo ""
+  } > "$NEW_SECTION_FILE"
+
+  awk -v sectionfile="$NEW_SECTION_FILE" '
+    /^## / && !inserted {
+      while ((getline line < sectionfile) > 0) print line
+      close(sectionfile)
+      inserted=1
+    }
+    { print }
+    END {
+      if (!inserted) {
+        while ((getline line < sectionfile) > 0) print line
+        close(sectionfile)
+      }
+    }
+  ' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+  rm -f "$NEW_SECTION_FILE"
+fi
+
+info "Opening ${EDITOR:-vi} on CHANGELOG.md — add high-level bullets, save, and exit."
+run "${EDITOR:-vi}" CHANGELOG.md
+
+# Verify user actually added content under the new section
+if [ "$DRY_RUN" -eq 0 ]; then
+  NEW_SECTION=$(awk -v ver="$NEW_VERSION" '
+    $0 == "## " ver { found=1; next }
+    found && /^## / { exit }
+    found { print }
+  ' CHANGELOG.md)
+  # Strip blanks and the empty stub bullet "- " to see if anything real was added.
+  CONTENT=$(printf '%s\n' "$NEW_SECTION" | sed '/^[[:space:]]*$/d' | sed '/^-[[:space:]]*$/d' || true)
+  if [ -z "$CONTENT" ]; then
+    die "No changelog entries added under ## $NEW_VERSION. Aborting."
+  fi
+  ok "Changelog entries detected"
+fi
+
+# ---------- commit + tag ----------
+info "Committing release"
+run git add package.json package-lock.json CHANGELOG.md
+run git commit -m "chore(release): $NEW_VERSION"
+
+info "Tagging $TAG"
+run git tag -a "$TAG" -m "$TAG"
+
+ROLLBACK_NEEDED=0
+ok "Release $NEW_VERSION ready locally."
+
+# ---------- next steps ----------
+cat <<EOF
+
+${BOLD}Next steps (run manually when ready):${RESET}
+
+  ${BLUE}# push branch and tag${RESET}
+  git push origin $EXPECTED_BRANCH
+  git push origin $TAG
+
+  ${BLUE}# create GitHub Release (requires gh CLI)${RESET}
+  gh release create $TAG \\
+    --title "$TAG" \\
+    --notes "\$(awk -v ver=\"$NEW_VERSION\" '
+      \$0 == \"## \" ver { found=1; next }
+      found && /^## / { exit }
+      found { print }
+    ' CHANGELOG.md)"
+
+  ${BLUE}# publish to npm${RESET}
+  npm run build-publish
+
+EOF

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -185,8 +185,15 @@ fi
 # diff --stat between the previous v* tag and HEAD, asks for 3-7 short
 # high-level bullets, and uses them to pre-fill the stub. Falls back to
 # an empty "- " stub if `claude` is missing or returns nothing.
+#
+# The prompt template lives at scripts/release-prompt.md so it can be edited
+# without touching this script. Placeholders: {{VERSION}}, {{PACKAGE_NAME}},
+# {{PREV_TAG}}, {{COMMITS}}, {{DIFFSTAT}}.
+PROMPT_TEMPLATE_FILE="$(dirname "$0")/release-prompt.md"
+
 get_ai_bullets() {
   command -v claude >/dev/null 2>&1 || return 1
+  [ -f "$PROMPT_TEMPLATE_FILE" ] || { warn "Prompt template not found at $PROMPT_TEMPLATE_FILE"; return 1; }
 
   local prev_tag commits diffstat pkg_name prompt output bullets
   prev_tag=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || true)
@@ -202,63 +209,14 @@ get_ai_bullets() {
 
   [ -n "$commits" ] || return 1
 
-  prompt=$(cat <<EOF
-As a Project Manager you are drafting a CHANGELOG entry for version $NEW_VERSION of the npm package $pkg_name.
-
-Write 3-7 high-level bullet points summarizing the changes below.
-
-=== WORKED EXAMPLE ===
-
-GIVEN commits like:
-  feat(summary): add pass-rate dashboard component
-  feat(summary): show Show summary checkbox in header
-  feat(summary): animated number transitions on chip counts
-  feat(llm-judge): wire end-to-end evaluation
-  feat(llm-judge): support system + user prompts
-  feat(llm-judge): return per-criterion scores
-  feat(status): introduce 'evaluating' and 'partial' kinds
-  refactor(row): redesign test case row layout
-  refactor(header): consolidate import/export/save controls
-  fix(row): clear flicker between LLM response and evaluation
-  chore: bump ws from 8.19.0 to 8.20.1
-  chore: update eslint config
-
-AND diff stat showing changes in:
-  src/components/llm-test-runner/summary/*
-  src/components/llm-test-runner/header/*
-  src/components/llm-test-runner/test-cases/*
-  src/lib/evaluation/evaluators/llm-judge/*
-
-EXPECTED output:
-- New summary dashboard
-- Test-runner UI redesigned
-- LLM-as-judge evaluation approach
-- Richer test status states
-
-Notice:
-- chore commits (dependency bumps, lint config) are dropped — not user-facing.
-- 4 related "summary" commits collapsed into one bullet.
-- 3 related "llm-judge" commits collapsed into one bullet.
-- 2 refactor commits about layout collapsed into "Test-runner UI redesigned".
-- The fix is internal mechanics, not surfaced — release note focuses on what users see.
-
-=== STRICT RULES ===
-
-- Output ONLY bullet lines (each starts with "- ").
-- No headings, no preamble, no commentary, no commit hashes, no PR numbers, no emojis.
-- One line per bullet.
-- Group related commits aggressively. One bullet can summarize 3-10 commits.
-- Drop chore / dependency-bump / lint / formatting / internal commits unless notable (security CVE = notable).
-- Prefer user-facing impact over internal mechanics.
-- Match the terse style of the EXPECTED output above — short noun phrases, no fluff.
-
-=== Commits since ${prev_tag:-HEAD} ===
-$commits
-
-=== Files changed ===
-$diffstat
-EOF
-)
+  # Load template and substitute placeholders. Bash ${var//A/B} handles
+  # multiline replacement values (commits, diffstat) safely.
+  prompt=$(cat "$PROMPT_TEMPLATE_FILE")
+  prompt="${prompt//\{\{VERSION\}\}/$NEW_VERSION}"
+  prompt="${prompt//\{\{PACKAGE_NAME\}\}/$pkg_name}"
+  prompt="${prompt//\{\{PREV_TAG\}\}/${prev_tag:-HEAD}}"
+  prompt="${prompt//\{\{COMMITS\}\}/$commits}"
+  prompt="${prompt//\{\{DIFFSTAT\}\}/$diffstat}"
 
   output=$(claude --print "$prompt" 2>/dev/null) || return 1
   bullets=$(printf '%s\n' "$output" | grep -E '^- ' || true)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -212,8 +212,8 @@ get_ai_bullets() {
   prompt="${prompt//\{\{DIFFSTAT\}\}/$diffstat}"
 
   output=$(claude --print "$prompt" 2>/dev/null) || return 1
-  bullets=$(printf '%s\n' "$output" | grep -E '^- ' || true)
-  [ -n "$bullets" ] || return 1
+  bullets=$(printf '%s\n' "$output" | awk '/^(###|- )/{found=1} found' || true)
+  printf '%s\n' "$bullets" | grep -qE '^- .' || return 1
 
   printf '%s\n' "$bullets"
 }
@@ -240,6 +240,8 @@ if [ "$DRY_RUN" -eq 0 ]; then
     if [ -n "$AI_BULLETS" ]; then
       printf '%s\n' "$AI_BULLETS"
     else
+      echo "### 🚀 What's new"
+      echo ""
       echo "- "
     fi
     echo ""
@@ -272,8 +274,11 @@ if [ "$DRY_RUN" -eq 0 ]; then
     found && /^## / { exit }
     found { print }
   ' CHANGELOG.md)
-  # Strip blanks and the empty stub bullet "- " to see if anything real was added.
-  CONTENT=$(printf '%s\n' "$NEW_SECTION" | sed '/^[[:space:]]*$/d' | sed '/^-[[:space:]]*$/d' || true)
+  CONTENT=$(printf '%s\n' "$NEW_SECTION" \
+    | sed '/^[[:space:]]*$/d' \
+    | sed '/^###/d' \
+    | sed '/^-[[:space:]]*$/d' \
+    || true)
   if [ -z "$CONTENT" ]; then
     die "No changelog entries added under ## $NEW_VERSION. Aborting."
   fi


### PR DESCRIPTION
Adds a local release automation script that handles version bumps, changelog drafting, and tagging with strict safety checks. The script optionally uses the Claude CLI to draft high-level changelog bullets from the commits since the last tag, then opens $EDITOR for review before committing.

### What this adds
`scripts/release.sh` — the release driver.
`RELEASING.md` — a single-page guide covering the flow, conventions, troubleshooting, and design rationale.
`package.json` — four npm aliases: release, release:patch, release:minor, release:major.

### How it works
```
npm run release:patch
  ├─ preflight (clean tree, on main, in sync with origin/main)
  ├─ lint + test + license-check
  ├─ npm version <bump> --no-git-tag-version
  ├─ assert vX.Y.Z tag is free (local + remote)
  ├─ Claude CLI drafts bullets from `git log` + `git diff --stat`
  ├─ $EDITOR opens CHANGELOG.md for review
  ├─ git commit -m "chore(release): X.Y.Z"
  └─ git tag -a vX.Y.Z -m "vX.Y.Z"
```
### Example — full sample run

`npm run release:minor` on `main`, current version `2.0.0`:

```
==> Preflight checks
✓   Working tree clean
✓   On branch main
==> Fetching origin...
✓   In sync with origin/main
==> Running lint...
==> Running tests...
Test Suites: 26 passed, 26 total
Tests:       216 passed, 216 total
==> Running license-check...
✓   All checks passed
==> Bumping version: minor
✓   New version: 2.1.0
✓   Tag v2.1.0 is free
==> Drafting changelog bullets via Claude CLI (optional)...
✓   AI drafted 5 bullets
==> Prepending stub to CHANGELOG.md
==> Opening vi on CHANGELOG.md — add high-level bullets, save, and exit.
```

`$EDITOR` opens with `CHANGELOG.md` pre-filled (sectioned by AI):

```
# Changelog

All notable changes to this project are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## 2.1.0

### 🚀 What's new

- Configurable rate-limiting on Run all
- CSV export now includes per-criterion scores
- Threshold input accepts decimals up to 4 places

### 🐛 Fixed

- Response-time drift on retries
- Race condition when running all tests with `delayMs=0`

## 2.0.0

### 🚀 What's new

- New summary dashboard
- LLM-as-judge evaluation approach
- Richer test status states (evaluating, partial)

### 🔧 Changed

- Test-runner UI redesigned

## 1.x.x
...
```

