### PR TITLE
Fix npm publish using npm OpenID Connect

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write # Required for OIDC trusted publishing
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -14,17 +18,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: "22"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
-          token: ${{ secrets.NPM_TOKEN }}
 
-      - name: Configure npm auth
-        run: |
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > "$NPM_CONFIG_USERCONFIG"
-          echo "registry=https://registry.npmjs.org/" >> "$NPM_CONFIG_USERCONFIG"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -42,9 +41,6 @@ jobs:
         run: npm run test
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-
-      - name: Verify NPM auth
-        run: npm whoami
 
       - name: Publish to npm
         run: npm publish --ignore-scripts


### PR DESCRIPTION
- update npm publishing from token based to trusted publisher, OpenID Connect