### PR TITLE
chore(ci): add Semgrep scanning and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # npm project (root)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+
+  # GitHub Actions workflow versions (actions/checkout, actions/setup-node, etc.)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,32 @@
+name: Semgrep
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Catches ruleset updates against unchanged code.
+    # GitHub Actions cron is UTC-only; 3:30 UTC Mon = 9:00 AM IST Mon.
+    - cron: "30 3 * * 1"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        run: >
+          semgrep scan
+          --config p/security-audit
+          --config p/secrets
+          --config p/javascript
+          --config p/typescript
+          --error


### PR DESCRIPTION
## Summary
- Adds a **Semgrep** workflow (`.github/workflows/semgrep.yml`) — automated code vulnerability scanning on every push/PR to `main`, plus a weekly scheduled scan. Uses free, open-source Semgrep Registry rulesets (`p/security-audit`, `p/secrets`, `p/javascript`, `p/typescript`) — no GitHub Advanced Security / Code Security license required.
- Adds **Dependabot** (`.github/dependabot.yml`) — weekly dependency update PRs for the npm project and for GitHub Actions versions.
- Neither addition pushes to `main` or touches release tagging — Dependabot only opens PRs for review, same as a human proposing a dependency bump, and Semgrep only scans/reports.

Mirrors the same setup added to the webapp repo in [FluxonApps/llm-testrunner#112](https://github.com/FluxonApps/llm-testrunner/pull/112).

## Test plan
- [x] Ran the exact Semgrep config from the workflow locally: `semgrep scan --config p/security-audit --config p/secrets --config p/javascript --config p/typescript --error` — 134 rules, 147 files, 0 findings, exit code 0.
- [x] `npm run lint` — no new errors/warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)