### PR TITLE
fix(rouge1): pin beta:Infinity to preserve recall-only scoring on js-rouge 3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@stencil/react-output-target": "^1.2.0",
         "@xenova/transformers": "^2.17.2",
         "bleu-score": "^1.0.4",
-        "js-rouge": "^3.0.0",
+        "js-rouge": "^3.2.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -85,7 +85,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -3372,7 +3371,6 @@
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.2.tgz",
       "integrity": "sha512-hOprMw/n1fyu5OOtZG7N8sqiKxPshR1oss/y1qr6r98cVV9NcVoCMz2x2TT2enkHan6pCMpiQgUU7vmN90lIVw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -3680,7 +3678,6 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -3912,7 +3909,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4524,7 +4520,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.44",
         "caniuse-lite": "^1.0.30001806",
@@ -5108,7 +5103,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -5217,8 +5213,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -5468,7 +5463,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5552,7 +5546,6 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -7588,9 +7581,9 @@
       }
     },
     "node_modules/js-rouge": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/js-rouge/-/js-rouge-3.0.0.tgz",
-      "integrity": "sha512-+rXcOCf53xU0uR8y75OQVHWWQaNFGWa+3g7OjnP9/Pau4EyZ56lpAO2GpVi4pjMkMmNKHwcxkiHNqCkMZK3T7A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/js-rouge/-/js-rouge-3.2.0.tgz",
+      "integrity": "sha512-2dvY28iFq5NcwxPNzc2zMgLVJED843m6CnKrCy0jYnOKd+QQhdkxI1wmdQspbcOAggo3K3gUZfhTSwmM+lWoBA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -9590,7 +9583,6 @@
       "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9784,7 +9776,8 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@stencil/react-output-target": "^1.2.0",
     "@xenova/transformers": "^2.17.2",
     "bleu-score": "^1.0.4",
-    "js-rouge": "^3.0.0",
+    "js-rouge": "^3.2.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -104,9 +104,9 @@
     "nodemon": "^3.1.11",
     "prettier": "^3.6.2",
     "puppeteer": "^24.3.0",
+    "tsup": "^8.5.0",
     "typescript-eslint": "^8.65.0",
-    "wait-on": "^9.0.3",
-    "tsup": "^8.5.0"
+    "wait-on": "^9.0.3"
   },
   "peerDependencies": {
     "jest": "^29.0.0",

--- a/src/lib/evaluation/evaluators/rouge1-evaluator.test.ts
+++ b/src/lib/evaluation/evaluators/rouge1-evaluator.test.ts
@@ -47,6 +47,21 @@ describe('performRouge1Evaluation', () => {
       ).toBeGreaterThan(0.5);
     });
 
+    it('should pass a short keyword fully contained in a much longer response (recall-only, not F1)', async () => {
+      // Guards the beta: Infinity pin against js-rouge's F1 default.
+      const request: EvaluationRequest = {
+        ...mockRequest,
+        actualResponse: 'The capital of Telangana is Hyderabad.',
+        expectedOutcome: 'Hyderabad',
+      };
+
+      const result = await performRouge1Evaluation(request);
+
+      expect(result.passed).toBe(true);
+      expect(result.keywordMatches[0].found).toBe(true);
+      expect(result.keywordMatches[0].evaluationApproachResult.score).toBe(1);
+    });
+
     it('should fail when keywords are not sufficiently present', async () => {
       const request: EvaluationRequest = {
         ...mockRequest,

--- a/src/lib/evaluation/evaluators/rouge1-evaluator.ts
+++ b/src/lib/evaluation/evaluators/rouge1-evaluator.ts
@@ -20,7 +20,8 @@ function evaluateKeyword(
 
   try {
     if (keyword.trim().length > 0 && candidate.length > 0) {
-      const rouge1 = rouge.n(candidate, keyword.trim(), { n: 1 });
+      // beta: Infinity keeps this recall-only (js-rouge >=3.1 defaults to F1).
+      const rouge1 = rouge.n(candidate, keyword.trim(), { n: 1, beta: Infinity });
       rouge1Score = isNaN(rouge1) ? 0 : rouge1;
     } else {
       console.warn(


### PR DESCRIPTION
## Summary
- Bumps `js-rouge` 3.0.0 → 3.2.0 (the version Dependabot proposed in #62) and pins `beta: Infinity` on the `rouge.n()` call in `rouge1-evaluator.ts` to preserve the library's existing recall-only scoring behavior.
- `js-rouge` >=3.1 changed `rouge.n()`'s default `beta` from `Infinity` (recall-only) to `1.0` (balanced F1) — a deliberate upstream change, not a bug. Since ROUGE-1 here means "does the expected keyword appear in the response," recall-only is the correct semantics: a short keyword against a long LLM response naturally has low precision, so F1 would fail matches that clearly contain the keyword.
- Verified numerically against the old (3.0.0) behavior — with `beta: Infinity`, 3.2.0 reproduces identical scores to 3.0.0 for every case checked (e.g. `"Hyderabad"` against `"The capital of Telangana is Hyderabad."` scores `1` either way; without the pin it drops to `0.25` under the new default and fails the pass threshold).
- The headless `toRouge1Match` matcher shares this same evaluator function, so this fix covers both surfaces.

Closes #62 (supersedes the raw dependency bump, which failed CI as-is).

## Test plan
- [x] New regression test: a short keyword fully contained in a much longer response still scores `1` and passes.
- [x] `npx jest --preset @stencil/core/testing src/lib/evaluation/evaluators/rouge1-evaluator.test.ts` — 9/9 passing.
- [x] `npx jest --preset @stencil/core/testing src/headless/tests/to-rouge1-match.spec.ts` — passing (this is the test that failed in #62's CI run).
- [x] Full suite (`npx stencil test --spec --e2e --passWithNoTests`) — 27/27 suites, 224/224 tests passing.
- [x] `npm run lint` — no new errors/warnings.

Note: `js-rouge` is a direct runtime dependency (ships in `dist/`), so this needs a patch release (`npm run release:patch`) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)