### PR TITLE
chore(dependabot): add cooldown to version-update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,18 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     groups:
       dev-dependencies:
         dependency-type: "development"
 
   # GitHub Actions workflow versions (actions/checkout, actions/setup-node, etc.)
+  # Note: semver-major-days isn't supported for this ecosystem, only default-days.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds `cooldown` to `.github/dependabot.yml`: `default-days: 7` on both ecosystems (npm, github-actions), plus `semver-major-days: 14` on npm since GitHub Actions doesn't support the semver-specific cooldown overrides, only `default-days`.
- Keeps Dependabot opening routine version-refresh PRs automatically (no auto-merge), but waits a few days after a version's release before proposing it — so we're not adopting something before the community has surfaced regressions, while still coming out of known vulnerabilities promptly.
- Cooldown only delays routine version-refresh PRs, not security-update PRs — those still open immediately regardless of cooldown.
- Doesn't affect any Dependabot PRs already open; only changes evaluation for future updates.

Mirrors [FluxonApps/llm-testrunner#127](https://github.com/FluxonApps/llm-testrunner/pull/127) (same request from Arvind, same reasoning).

## Test plan
- [x] Reviewed the YAML diff for correct `cooldown` syntax (matches the syntax already used and reasoned through in llm-testrunner#127).
- [x] Confirmed against GitHub's Dependabot docs that `default-days` is supported on all listed ecosystems, but `semver-major-days` is only supported on ecosystems that explicitly list it — `github-actions` is not one of them, hence it only sets `default-days`.
- This config can't be exercised locally (Dependabot runs server-side on GitHub); the real test is observing that future Dependabot PRs on this repo respect the 7/14-day windows once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)