### PR TITLE
fix(release): use patch bump for automated dependency releases

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Bump version
         id: version
         run: |
-          npm version minor --no-git-tag-version --allow-same-version >/dev/null
+          npm version patch --no-git-tag-version --allow-same-version >/dev/null
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$NEW_VERSION" >> "$GITHUB_OUTPUT"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -139,7 +139,7 @@ Dependabot/security bumps still go through the same manual PR review you do toda
 ```
 Dependabot PR is reviewed and merged into main (manual, as today)
   └─ .github/workflows/release-pr.yml
-       ├─ bumps package.json (minor)
+       ├─ bumps package.json (patch)
        ├─ drafts CHANGELOG bullets via Gemini (scripts/generate-dependency-changelog.mjs)
        └─ opens/updates a single `release/vX.Y.Z` PR (idempotent — multiple
           Dependabot merges in the same week collapse into one PR)


### PR DESCRIPTION
## Summary
- Automated Dependabot/security releases (`release-pr.yml`) now bump `patch` instead of `minor`, since these are routine dependency-only updates rather than feature work.
- Updates `RELEASING.md` and local docs to match.

Follow-up to feedback on #67 (currently proposing 2.3.0/minor) — once merged, #67 will be superseded by a 2.2.3 patch release PR.

## Test plan
- [ ] Merge this PR
- [ ] Confirm the rebuilt release PR (2.2.3) targets patch, not minor