### PR TITLE
chore(release): 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.3
+
+### 🔧 Changed
+
+- Bump the dev-dependencies group with 13 updates (jest/puppeteer pinned for Stencil compatibility)
+
 ## 2.2.2
 
 ### 🔧 Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-testrunner-components",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-testrunner-components",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^2.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-testrunner-components",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A Stencil web component library for LLM test runner functionality",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",


### PR DESCRIPTION
Automated release PR bundling Dependabot/security updates merged since the last release. Tagging v2.2.3 and publishing to npm happen once this is reviewed and merged.

Supersedes #67 — rebuilt as a patch release (2.2.3) instead of minor (2.3.0) per feedback.