### PR TITLE
chore: ignore local Claude Code config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ UserInterfaceState.xcuserstate
 generated/
 
 CLAUDE.md
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore`, alongside the existing `CLAUDE.md` entry.
- `.claude/` holds per-developer session state (e.g. `settings.local.json`) that shouldn't be committed or shared across machines.

## Test plan
- [x] N/A — `.gitignore`-only change, no build/test impact.