### PR TITLE
[1/7] feat(ui): add shared UI primitives for the Figma redesign

### DIFF
--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -71,6 +71,7 @@ function nextFrame(): Promise<void> {
     '../error-message/error-message.css',
     '../../lib/ui/button/button.css',
     '../../lib/ui/icon-button/icon-button.css',
+    '../../lib/ui/tooltip/tooltip.css',
   ],
   shadow: true,
 })

--- a/src/lib/form/components/app-chips.css
+++ b/src/lib/form/components/app-chips.css
@@ -21,20 +21,14 @@
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: var(--spacing-1) var(--spacing-2);
-  font-size: var(--font-size-xs);
+  height: 32px;
+  padding: 5px var(--spacing-3);
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
-  border-radius: var(--radius-md);
-  background: var(--accent);
+  color: color-mix(in srgb, var(--foreground) 55%, var(--muted-foreground));
+  border-radius: var(--radius-full);
+  background: var(--secondary);
   border: var(--border-width) solid var(--border);
-}
-
-/* Keyword-style chip override (non-URL chips) */
-.app-chips__chip:not(:has(a)) {
-  background: var(--info);
-  color: var(--info-foreground);
-  border: none;
-  border-radius: var(--radius-2xl);
 }
 
 .app-chips__link {
@@ -54,10 +48,9 @@
   background: none;
   border: none;
   cursor: pointer;
-  font-size: var(--font-size-xs);
   padding: 0;
-  width: var(--spacing-4);
-  height: var(--spacing-4);
+  width: 16px;
+  height: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -66,9 +59,9 @@
   opacity: var(--opacity-muted);
 }
 
-.app-chips__chip:not(:has(a)) .app-chips__remove {
-  color: var(--info-foreground);
-  opacity: var(--opacity-hover);
+.app-chips__remove svg {
+  width: 14px;
+  height: 14px;
 }
 
 .app-chips__remove:hover {
@@ -76,22 +69,81 @@
   background: var(--muted);
 }
 
-.app-chips__chip:not(:has(a)) .app-chips__remove:hover {
-  background: rgba(255, 255, 255, 0.2);
+/* Add-chip pill — same shape/height as a regular chip, but holds a live
+ * input with an explicit cancel (X) and confirm (→) action instead of
+ * relying on blur to close it. */
+.app-chips__adding {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  height: 32px;
+  min-width: 200px;
+  padding: 5px 5px 5px 13px;
+  border-radius: var(--radius-full);
+  background: var(--muted);
+  border: var(--border-width) solid var(--border);
+  /* A neutral focus ring, not the blue --ring-soft used for form-field
+   * focus elsewhere — this pill isn't a validation/focus state. */
+  box-shadow: 0 0 0 3px rgb(115 115 115 / 0.35);
 }
 
 .app-chips__input {
-  border: var(--border-width) solid var(--input);
-  border-radius: var(--radius-md);
-  padding: var(--spacing-2);
-  font-size: var(--font-size-xs);
+  flex: 1;
+  min-width: 0;
+  border: none;
   outline: none;
-  min-width: 120px;
-  background: var(--background);
+  background: transparent;
+  padding: 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: color-mix(in srgb, var(--foreground) 55%, var(--muted-foreground));
+}
+
+.app-chips__cancel {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+
+.app-chips__cancel svg {
+  width: 14px;
+  height: 14px;
+}
+
+.app-chips__cancel:hover {
   color: var(--foreground);
 }
 
-.app-chips__input:focus {
-  border-color: var(--ring);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+.app-chips__confirm {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  cursor: pointer;
+  transition: opacity 120ms ease;
+}
+
+.app-chips__confirm svg {
+  width: 14px;
+  height: 14px;
+}
+
+.app-chips__confirm:disabled {
+  opacity: var(--opacity-disabled);
+  cursor: not-allowed;
 }

--- a/src/lib/form/components/app-chips.tsx
+++ b/src/lib/form/components/app-chips.tsx
@@ -1,9 +1,11 @@
-import { Component, Prop, h, Event, EventEmitter } from '@stencil/core';
+import { Component, Prop, State, h, Event, EventEmitter } from '@stencil/core';
 import { ChipsConfig } from '../schema';
+import { IconButton } from '../../ui/icon-button/index';
+import { ArrowRightIcon, PlusIcon, XIcon } from '../../ui/icons/icons';
 
 @Component({
   tag: 'app-chips',
-  styleUrl: 'app-chips.css',
+  styleUrls: ['app-chips.css', '../../ui/icon-button/icon-button.css'],
   shadow: true,
 })
 export class AppChips {
@@ -14,11 +16,11 @@ export class AppChips {
 
   @Event() removeChip: EventEmitter<{ value: string }>;
 
-  private emitAddChip(val: string) {
-    this.addChip.emit({
-      value: val,
-    });
-  }
+  /** The add-chip input is hidden behind a "+" button until the user
+   * clicks it — matches the design's persistent trailing add button
+   * rather than an always-visible text input. */
+  @State() isAdding = false;
+  @State() draft = '';
 
   private emitRemoveChip(value: string) {
     this.removeChip.emit({
@@ -30,6 +32,56 @@ export class AppChips {
     const normalized = value.trim().toLowerCase();
     return this.value.some(chip => chip.trim().toLowerCase() === normalized);
   }
+
+  private openAdding = () => {
+    this.isAdding = true;
+    this.draft = '';
+  };
+
+  private cancelAdding = () => {
+    this.isAdding = false;
+    this.draft = '';
+  };
+
+  private submitDraft = () => {
+    const val = this.draft.trim();
+    if (!val || this.hasDuplicateChip(val)) {
+      this.draft = '';
+      return;
+    }
+
+    this.addChip.emit({ value: val });
+    this.draft = '';
+  };
+
+  /** Clicking away from the input saves whatever was typed (and closes the
+   * add-chip UI), rather than silently discarding it. */
+  private handleInputBlur = () => {
+    this.submitDraft();
+    this.isAdding = false;
+  };
+
+  /** Keeps focus on the input when the Cancel/Confirm buttons are clicked,
+   * so their onClick fires before — not after — handleInputBlur would run
+   * and save a draft the user meant to cancel. */
+  private keepInputFocused = (e: MouseEvent) => {
+    e.preventDefault();
+  };
+
+  private handleDraftInput = (e: Event) => {
+    this.draft = (e.target as HTMLInputElement).value;
+  };
+
+  private handleInputKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      this.submitDraft();
+      return;
+    }
+
+    if (e.key === 'Escape') {
+      this.cancelAdding();
+    }
+  };
 
   render() {
     const c = this.config;
@@ -71,32 +123,56 @@ export class AppChips {
               <button
                 class="app-chips__remove"
                 type="button"
+                aria-label={`Remove ${chip}`}
                 onClick={() => this.emitRemoveChip(chip)}
               >
-                ×
+                <XIcon />
               </button>
             </span>
           ))}
 
-          <input
-            class="app-chips__input"
-            type={c.type || 'text'}
-            {...allowedAttrs}
-            onKeyDown={(e: KeyboardEvent) => {
-              if (e.key === 'Enter') {
-                const input = e.target as HTMLInputElement;
-                const val = input.value.trim();
-                if (!val) return;
-                if (this.hasDuplicateChip(val)) {
-                  input.value = '';
-                  return;
-                }
-
-                this.emitAddChip(val);
-                input.value = '';
-              }
-            }}
-          />
+          {this.isAdding ? (
+            <span class="app-chips__adding">
+              <input
+                class="app-chips__input"
+                type={c.type || 'text'}
+                {...allowedAttrs}
+                value={this.draft}
+                autoFocus
+                onInput={this.handleDraftInput}
+                onKeyDown={this.handleInputKeyDown}
+                onBlur={this.handleInputBlur}
+              />
+              <button
+                class="app-chips__cancel"
+                type="button"
+                aria-label="Cancel"
+                onMouseDown={this.keepInputFocused}
+                onClick={this.cancelAdding}
+              >
+                <XIcon />
+              </button>
+              <button
+                class="app-chips__confirm"
+                type="button"
+                aria-label="Add"
+                disabled={!this.draft.trim()}
+                onMouseDown={this.keepInputFocused}
+                onClick={this.submitDraft}
+              >
+                <ArrowRightIcon />
+              </button>
+            </span>
+          ) : (
+            <IconButton
+              variant="outline"
+              class="app-chips__add"
+              title="Add"
+              onClick={this.openAdding}
+            >
+              <PlusIcon />
+            </IconButton>
+          )}
         </div>
       </div>
     );

--- a/src/lib/form/components/app-select.css
+++ b/src/lib/form/components/app-select.css
@@ -36,3 +36,15 @@
   border-color: var(--ring);
   box-shadow: 0 0 0 4px var(--ring-soft);
 }
+
+/* Compact — a small, inline pill (value + chevron, no visible label). Used
+ * where the select sits inline in a field header rather than a block form. */
+.app-select__select--compact {
+  width: auto;
+  min-width: 0;
+  padding: 4px 22px 4px 10px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-xs);
+  background-size: 10px;
+  background-position: right 8px center;
+}

--- a/src/lib/form/components/app-select.tsx
+++ b/src/lib/form/components/app-select.tsx
@@ -23,7 +23,7 @@ export class AppSelect {
       autocomplete: c.autocomplete,
     };
     return (
-      <div class="app-select">
+      <div class={{ 'app-select': true, 'app-select--compact': !!c.compact }}>
         {c.label && (
           <label class="app-select__label" htmlFor={c.name}>
             {c.label}
@@ -33,7 +33,11 @@ export class AppSelect {
         <div>
           <select
             {...allowedAttrs}
-            class="app-select__select"
+            aria-label={c.label ? undefined : c.ariaLabel}
+            class={{
+              'app-select__select': true,
+              'app-select__select--compact': !!c.compact,
+            }}
             onInput={(e: Event) => {
               const raw = (e.target as HTMLSelectElement).value;
               const matched = c.optionList.find(opt => String(opt) === raw);

--- a/src/lib/form/components/app-textarea.css
+++ b/src/lib/form/components/app-textarea.css
@@ -47,6 +47,12 @@
   box-shadow: 0 0 0 4px var(--ring-soft);
 }
 
+.textarea-element--invalid,
+.textarea-element--invalid:focus {
+  border-color: var(--destructive);
+  box-shadow: 0 0 0 3px var(--destructive-soft-bg);
+}
+
 .textarea-wrapper--read-only .textarea-label {
   color: var(--muted-foreground);
 }

--- a/src/lib/form/components/app-textarea.tsx
+++ b/src/lib/form/components/app-textarea.tsx
@@ -61,8 +61,12 @@ export class AppTextarea {
 
         <textarea
           {...allowedAttrs}
-          class="textarea-element"
+          class={{
+            'textarea-element': true,
+            'textarea-element--invalid': !!c.invalid,
+          }}
           value={this.value}
+          aria-invalid={c.invalid ? 'true' : undefined}
           onInput={this.handleChange}
         ></textarea>
 

--- a/src/lib/form/schema/base-input-field-config.ts
+++ b/src/lib/form/schema/base-input-field-config.ts
@@ -25,12 +25,16 @@ export interface BaseInputFieldConfig {
   fieldType: FormFieldType;
   type?: string;
   label?: string;
+  /** Accessible name for the control when `label` is omitted for a compact, unlabeled layout. */
+  ariaLabel?: string;
   placeholder?: string;
   defaultValue?: any;
   autocomplete?: string;
   required?: boolean;
   disabled?: boolean;
   readOnly?: boolean;
+  /** Shows the field's invalid/error styling (e.g. a missing required value). */
+  invalid?: boolean;
   helpText?: string;
   validation?: InputFieldValidation;
   hidden?: boolean;

--- a/src/lib/form/schema/form-control-config.ts
+++ b/src/lib/form/schema/form-control-config.ts
@@ -18,4 +18,6 @@ export interface ChipsConfig extends BaseInputFieldConfig {
 export interface SelectConfig extends BaseInputFieldConfig {
   fieldType: FormFieldType.SELECT;
   optionList: string[];
+  /** Renders as a small, label-less inline pill instead of the default full-width block control. */
+  compact?: boolean;
 }

--- a/src/lib/ui/icons/icons.tsx
+++ b/src/lib/ui/icons/icons.tsx
@@ -141,3 +141,43 @@ export const XIcon: FunctionalComponent<IconProps> = ({ class: cls }) => (
     <line x1="6" y1="6" x2="18" y2="18" />
   </svg>
 );
+
+/** Circled "i" — used for inline field help. */
+export const InfoIcon: FunctionalComponent<IconProps> = ({ class: cls }) => (
+  <svg {...baseProps} class={cls}>
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="16" x2="12" y2="11" />
+    <line x1="12" y1="8" x2="12.01" y2="8" />
+  </svg>
+);
+
+/** Clock over a document — used for the Chat history toggle. */
+export const FileClockIcon: FunctionalComponent<IconProps> = ({
+  class: cls,
+}) => (
+  <svg {...baseProps} class={cls}>
+    <path d="M16 22h2a2 2 0 0 0 2-2V7.5L14.5 2H6a2 2 0 0 0-2 2v3" />
+    <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+    <circle cx="8" cy="16" r="6" />
+    <path d="M8 14v2l1 1" />
+  </svg>
+);
+
+/** Chevron pointing down — used for select affordances and disclosures. */
+export const ChevronDownIcon: FunctionalComponent<IconProps> = ({
+  class: cls,
+}) => (
+  <svg {...baseProps} class={cls}>
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
+/** Arrow pointing right — used to confirm/submit an inline entry. */
+export const ArrowRightIcon: FunctionalComponent<IconProps> = ({
+  class: cls,
+}) => (
+  <svg {...baseProps} class={cls}>
+    <line x1="5" y1="12" x2="19" y2="12" />
+    <polyline points="12 5 19 12 12 19" />
+  </svg>
+);

--- a/src/lib/ui/threshold-input/threshold-input.css
+++ b/src/lib/ui/threshold-input/threshold-input.css
@@ -65,3 +65,17 @@
 .threshold-input__message--error {
   color: var(--destructive);
 }
+
+/* Compact — a small inline field (no label, no reserved bottom margin).
+ * Used where the threshold sits inline in a field header. */
+.threshold-input--compact {
+  margin-bottom: 0;
+  display: inline-flex;
+}
+
+.threshold-input__input--compact {
+  width: 56px;
+  padding: 4px 8px;
+  font-size: var(--font-size-xs);
+  border-radius: var(--radius-md);
+}

--- a/src/lib/ui/threshold-input/threshold-input.tsx
+++ b/src/lib/ui/threshold-input/threshold-input.tsx
@@ -22,6 +22,8 @@ export interface ThresholdInputProps {
   min?: number;
   max?: number;
   inputId?: string;
+  /** Renders as a small, label-less inline field instead of the default block layout. */
+  compact?: boolean;
 }
 
 @Component({
@@ -36,6 +38,7 @@ export class ThresholdInput implements ThresholdInputProps {
   @Prop() min?: number = 0;
   @Prop() max?: number = 1;
   @Prop() inputId?: string;
+  @Prop() compact?: boolean = false;
 
   /**
    * What the user has typed. Kept separate from `value` so that an invalid
@@ -140,8 +143,8 @@ export class ThresholdInput implements ThresholdInputProps {
     const isInvalid = this.errorMessage !== null;
 
     return (
-      <div class="threshold-input">
-        {this.label && (
+      <div class={{ 'threshold-input': true, 'threshold-input--compact': this.compact }}>
+        {this.label && !this.compact && (
           <label class="threshold-input__label" htmlFor={id}>
             {this.label}
           </label>
@@ -151,6 +154,7 @@ export class ThresholdInput implements ThresholdInputProps {
             id={id}
             class={{
               'threshold-input__input': true,
+              'threshold-input__input--compact': this.compact,
               'threshold-input__input--invalid': isInvalid,
             }}
             type="number"
@@ -159,6 +163,7 @@ export class ThresholdInput implements ThresholdInputProps {
             min={this.min}
             max={this.max}
             value={this.draft}
+            aria-label={this.compact ? (this.label || 'Threshold') : undefined}
             aria-invalid={isInvalid ? 'true' : 'false'}
             aria-describedby={this.errorMessage ? messageId : undefined}
             onInput={this.handleInput}

--- a/src/lib/ui/tooltip/index.ts
+++ b/src/lib/ui/tooltip/index.ts
@@ -1,0 +1,2 @@
+export { Tooltip } from './tooltip';
+export type { TooltipProps } from './tooltip';

--- a/src/lib/ui/tooltip/tooltip.css
+++ b/src/lib/ui/tooltip/tooltip.css
@@ -1,0 +1,47 @@
+.ui-tooltip {
+  position: relative;
+  display: inline-flex;
+  outline: none;
+}
+
+.ui-tooltip__bubble {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  width: max-content;
+  max-width: 240px;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--foreground);
+  color: var(--background);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-normal);
+  line-height: 1.4;
+  letter-spacing: var(--letter-spacing-normal);
+  text-align: center;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 120ms ease, transform 120ms ease;
+  z-index: var(--z-tooltip);
+}
+
+.ui-tooltip__bubble::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--foreground);
+}
+
+.ui-tooltip:hover .ui-tooltip__bubble,
+.ui-tooltip:focus-visible .ui-tooltip__bubble,
+.ui-tooltip:focus-within .ui-tooltip__bubble {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}

--- a/src/lib/ui/tooltip/tooltip.tsx
+++ b/src/lib/ui/tooltip/tooltip.tsx
@@ -1,0 +1,29 @@
+import { h, FunctionalComponent } from '@stencil/core';
+
+let nextId = 0;
+
+export interface TooltipProps {
+  content: string;
+  class?: string;
+}
+
+/** Wraps a trigger (usually an icon) with a custom-styled bubble tooltip
+ * that appears above it on hover/focus — used in place of the native
+ * `title` attribute, which can't be styled or positioned. */
+export const Tooltip: FunctionalComponent<TooltipProps> = (props, children) => {
+  const { content, class: className } = props;
+  const id = `ui-tooltip-${++nextId}`;
+
+  return (
+    <span
+      class={['ui-tooltip', className].filter(Boolean).join(' ')}
+      tabIndex={0}
+      aria-describedby={id}
+    >
+      {children}
+      <span class="ui-tooltip__bubble" role="tooltip" id={id}>
+        {content}
+      </span>
+    </span>
+  );
+};

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -121,8 +121,8 @@
   --popover: #ffffff;
   --popover-foreground: #0a0a0a;
 
-  --primary: #0a0a0a;
-  --primary-foreground: #fafafa;
+  --primary: #0e35ff;
+  --primary-foreground: #f9fafb;
 
   --secondary: #f4f4f5;
   --secondary-foreground: #0a0a0a;
@@ -181,8 +181,8 @@
   --popover: #171717;
   --popover-foreground: #fafafa;
 
-  --primary: #fafafa;
-  --primary-foreground: #0a0a0a;
+  --primary: #3b5bff;
+  --primary-foreground: #f9fafb;
 
   --secondary: #27272a;
   --secondary-foreground: #fafafa;


### PR DESCRIPTION
## Summary

**1 of 7** in the "D - LLM Test Runner" Figma redesign stack — see the stack overview in #71 (being closed in favor of this stack) / linked from the last PR.

Foundational, self-contained pieces with no feature wiring yet:
- New reusable `Tooltip` component (`src/lib/ui/tooltip/`) to replace native `title` attributes with a custom-styled, positioned bubble.
- New icons: `InfoIcon`, `FileClockIcon`, `ChevronDownIcon`, `ArrowRightIcon`.
- Primary color token swapped to Figma's blue.
- Compact/inline variants for `app-select`, `app-textarea`, `app-chips`, and `threshold-input`, plus the schema flags that enable them — used by the expected-outcome card redesign later in this stack.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx stencil test --spec --passWithNoTests` — 225/225 passing
- [x] `npx eslint` on changed files — no new warnings/errors vs `main`