### PR TITLE
[2/7] feat(validation): add primary expected-outcome field gating helper

### DIFF
--- a/src/lib/test-cases/test-case-validation.ts
+++ b/src/lib/test-cases/test-case-validation.ts
@@ -1,0 +1,34 @@
+import { ExpectedOutcomeField, TestCase } from '../../types/llm-test-runner';
+
+/**
+ * Whether the first (primary) expected-outcome field is missing a value it
+ * needs — a dynamic-mode textarea is resolved at run time (or fails with a
+ * clear runtime error if no resolver is configured), so it's exempt here
+ * regardless of whether dynamic resolution is wired up. Only the primary
+ * field gates Run, matching the "This field is mandatory" treatment shown
+ * only on that field in the design.
+ */
+export function isPrimaryExpectedOutcomeMissing(
+  fields: ExpectedOutcomeField[] | undefined,
+): boolean {
+  const primary = (fields || [])[0];
+  if (!primary) return false;
+
+  if (primary.type === 'textarea') {
+    if (primary.outcomeMode === 'dynamic') return false;
+    return !primary.value?.trim();
+  }
+
+  if (primary.type === 'chips-input') {
+    return !primary.value || primary.value.length === 0;
+  }
+
+  return false;
+}
+
+export function isTestCaseRunnable(testCase: TestCase): boolean {
+  return (
+    !!testCase.question.trim() &&
+    !isPrimaryExpectedOutcomeMissing(testCase.expectedOutcome)
+  );
+}


### PR DESCRIPTION
## Summary

**2 of 7** in the "D - LLM Test Runner" Figma redesign stack (stacked on #72).

Adds `isPrimaryExpectedOutcomeMissing`/`isTestCaseRunnable` — pure logic, no UI wiring yet. Used by the expected-outcome card redesign (mandatory-field message) and the row/Run All gating later in this stack, matching the Figma proto's mandatory primary-field state.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx stencil test --spec --passWithNoTests` — 225/225 passing
- [x] `npx eslint` — clean