### PR TITLE
[3/7] feat(ui): redesign expected-outcome card per Figma

### DIFF
--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -65,6 +65,7 @@ function nextFrame(): Promise<void> {
     'summary/llm-test-runner-summary.css',
     'test-cases/llm-test-cases.css',
     'test-cases/llm-test-case-row.css',
+    'test-cases/expected-outcome-renderer.css',
     'test-cases/actions/row-actions.css',
     'test-cases/evaluation/evaluation-summary.css',
     'test-cases/output/response-output.css',

--- a/src/components/llm-test-runner/test-cases/expected-outcome-renderer.css
+++ b/src/components/llm-test-runner/test-cases/expected-outcome-renderer.css
@@ -1,0 +1,266 @@
+/* ------------------------------------------------------------------ */
+/* Expected outcome fields — a primary card (always visible) plus any   */
+/* additional fields tucked behind a shared "More Options" disclosure.  */
+/* ------------------------------------------------------------------ */
+
+.expected-outcome-renderer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  width: 100%;
+}
+
+/* The outer card — holds the primary field (always visible) and, when
+ * present, the "More Options" disclosure for every field after it. Both
+ * live inside this one bordered container, not side-by-side cards. */
+.expected-outcome-renderer__outer-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--background);
+  border: var(--border-width) solid var(--border);
+  border-radius: var(--radius-2xl);
+  /* No overflow:hidden here — it would clip tooltips that pop up above
+   * fields near the top of the card. Instead, whichever child ends up
+   * flush against the bottom edge rounds its own bottom corners below. */
+}
+
+.expected-outcome-renderer__primary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4) var(--spacing-6) var(--spacing-2);
+}
+
+.expected-outcome-renderer__card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-5);
+  flex: 1;
+  min-width: 0;
+  padding: var(--spacing-6);
+  background: var(--background);
+  border: var(--border-width) solid var(--border);
+  border-radius: var(--radius-2xl);
+}
+
+.expected-outcome-renderer__card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+}
+
+.expected-outcome-renderer__card-title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--foreground);
+}
+
+.expected-outcome-renderer__info-icon {
+  display: inline-flex;
+  color: var(--muted-foreground);
+}
+
+.expected-outcome-renderer__info-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.expected-outcome-renderer__card-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  flex-shrink: 0;
+}
+
+.expected-outcome-renderer__card-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.expected-outcome-renderer__mandatory-message {
+  /* Pull flush against the field above it — cancels the parent's 12px flex
+   * `gap` exactly (that gap is sized for spacing between full controls, not
+   * a hugging error message). Anything more negative than -12px would push
+   * this up into the field's own border. */
+  margin: -12px 0 0;
+  font-size: var(--font-size-xs);
+  color: var(--destructive-soft-fg);
+}
+
+.expected-outcome-renderer__chips-wrap--invalid {
+  padding: var(--spacing-2);
+  border-radius: var(--radius-lg);
+  border: var(--border-width) solid var(--destructive);
+  box-shadow: 0 0 0 3px var(--destructive-soft-bg);
+}
+
+.expected-outcome-renderer__text-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--spacing-2) var(--spacing-3);
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  border: var(--border-width) solid var(--input);
+  border-radius: var(--radius-lg);
+  background: var(--background);
+  color: var(--foreground);
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.expected-outcome-renderer__text-input:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 4px var(--ring-soft);
+}
+
+/* ------------------------------------------------------------------ */
+/* "More Options" — shared disclosure grouping every field after the    */
+/* first one, rendered as a row of cards on a muted tray.                */
+/* ------------------------------------------------------------------ */
+
+.expected-outcome-renderer__more-options-summary {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-5) var(--spacing-4);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--muted-foreground);
+  background: var(--background);
+  user-select: none;
+  list-style: none;
+  transition: color 150ms ease;
+}
+
+/* Whichever element ends up flush against the outer card's bottom edge
+ * rounds its own bottom corners to match it (see the note on
+ * .expected-outcome-renderer__outer-card for why we don't just clip). */
+.expected-outcome-renderer__more-options:not([open])
+  .expected-outcome-renderer__more-options-summary {
+  border-radius: 0 0 var(--radius-2xl) var(--radius-2xl);
+}
+
+.expected-outcome-renderer__more-options-summary:hover {
+  color: var(--foreground);
+}
+
+.expected-outcome-renderer__more-options-summary::-webkit-details-marker {
+  display: none;
+}
+
+.expected-outcome-renderer__more-options-summary::marker {
+  display: none;
+  content: '';
+}
+
+.expected-outcome-renderer__more-options-chevron {
+  width: 16px;
+  height: 16px;
+  transition: transform 200ms ease;
+}
+
+.expected-outcome-renderer__more-options[open]
+  .expected-outcome-renderer__more-options-chevron {
+  transform: rotate(180deg);
+}
+
+.expected-outcome-renderer__more-options-content {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  background: var(--muted);
+  border-top: var(--border-width) solid var(--border);
+  border-radius: 0 0 var(--radius-2xl) var(--radius-2xl);
+}
+
+.expected-outcome-renderer__more-options-content
+  .expected-outcome-renderer__card {
+  flex: 1 1 260px;
+}
+
+/* ------------------------------------------------------------------ */
+/* Per-field advanced options (evaluation source/extractor, LLM-judge   */
+/* criteria) — a small, rarely-opened disclosure inside each card.      */
+/* ------------------------------------------------------------------ */
+
+.expected-outcome-renderer__options {
+  border: var(--border-width) solid var(--border);
+  border-radius: var(--radius-lg);
+  background: transparent;
+  overflow: hidden;
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.expected-outcome-renderer__options[open] {
+  background: var(--muted);
+  border-color: var(--border-strong);
+}
+
+.expected-outcome-renderer__options-summary {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wider);
+  color: var(--muted-foreground);
+  padding: var(--spacing-3) var(--spacing-3);
+  user-select: none;
+  list-style: none;
+  transition: color 150ms ease;
+}
+
+.expected-outcome-renderer__options-summary:hover {
+  color: var(--foreground);
+}
+
+.expected-outcome-renderer__options-summary::-webkit-details-marker {
+  display: none;
+}
+
+.expected-outcome-renderer__options-summary::marker {
+  display: none;
+  content: '';
+}
+
+.expected-outcome-renderer__options-summary::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor;
+  transition: transform 200ms ease;
+  transform-origin: 25% 50%;
+  flex-shrink: 0;
+}
+
+.expected-outcome-renderer__options[open]
+  .expected-outcome-renderer__options-summary::before {
+  transform: rotate(90deg);
+}
+
+.expected-outcome-renderer__options-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  padding: 0 var(--spacing-3) var(--spacing-3);
+}
+
+@media (max-width: 768px) {
+  .expected-outcome-renderer__primary,
+  .expected-outcome-renderer__card {
+    padding: var(--spacing-4);
+  }
+}

--- a/src/components/llm-test-runner/test-cases/expected-outcome-renderer.css
+++ b/src/components/llm-test-runner/test-cases/expected-outcome-renderer.css
@@ -1,8 +1,3 @@
-/* ------------------------------------------------------------------ */
-/* Expected outcome fields — a primary card (always visible) plus any   */
-/* additional fields tucked behind a shared "More Options" disclosure.  */
-/* ------------------------------------------------------------------ */
-
 .expected-outcome-renderer {
   display: flex;
   flex-direction: column;
@@ -10,18 +5,13 @@
   width: 100%;
 }
 
-/* The outer card — holds the primary field (always visible) and, when
- * present, the "More Options" disclosure for every field after it. Both
- * live inside this one bordered container, not side-by-side cards. */
 .expected-outcome-renderer__outer-card {
   display: flex;
   flex-direction: column;
   background: var(--background);
   border: var(--border-width) solid var(--border);
   border-radius: var(--radius-2xl);
-  /* No overflow:hidden here — it would clip tooltips that pop up above
-   * fields near the top of the card. Instead, whichever child ends up
-   * flush against the bottom edge rounds its own bottom corners below. */
+  /* No overflow:hidden — it would clip tooltips popping up above top fields. */
 }
 
 .expected-outcome-renderer__primary {
@@ -83,10 +73,7 @@
 }
 
 .expected-outcome-renderer__mandatory-message {
-  /* Pull flush against the field above it — cancels the parent's 12px flex
-   * `gap` exactly (that gap is sized for spacing between full controls, not
-   * a hugging error message). Anything more negative than -12px would push
-   * this up into the field's own border. */
+  /* Cancels the parent's 12px flex gap to sit flush against the field above. */
   margin: -12px 0 0;
   font-size: var(--font-size-xs);
   color: var(--destructive-soft-fg);
@@ -118,11 +105,6 @@
   box-shadow: 0 0 0 4px var(--ring-soft);
 }
 
-/* ------------------------------------------------------------------ */
-/* "More Options" — shared disclosure grouping every field after the    */
-/* first one, rendered as a row of cards on a muted tray.                */
-/* ------------------------------------------------------------------ */
-
 .expected-outcome-renderer__more-options-summary {
   cursor: pointer;
   display: flex;
@@ -138,9 +120,7 @@
   transition: color 150ms ease;
 }
 
-/* Whichever element ends up flush against the outer card's bottom edge
- * rounds its own bottom corners to match it (see the note on
- * .expected-outcome-renderer__outer-card for why we don't just clip). */
+/* Rounds bottom corners to match the outer card when this sits flush against it. */
 .expected-outcome-renderer__more-options:not([open])
   .expected-outcome-renderer__more-options-summary {
   border-radius: 0 0 var(--radius-2xl) var(--radius-2xl);
@@ -185,11 +165,6 @@
   .expected-outcome-renderer__card {
   flex: 1 1 260px;
 }
-
-/* ------------------------------------------------------------------ */
-/* Per-field advanced options (evaluation source/extractor, LLM-judge   */
-/* criteria) — a small, rarely-opened disclosure inside each card.      */
-/* ------------------------------------------------------------------ */
 
 .expected-outcome-renderer__options {
   border: var(--border-width) solid var(--border);

--- a/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
+++ b/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
@@ -11,6 +11,11 @@ import {
 } from '../../../lib/evaluation/constants';
 import { getAllowedApproachesForFieldType } from '../../../lib/evaluation/field-evaluation-approach';
 import { ExpectedOutcomeChange } from '../../../lib/test-cases/test-case-mutations';
+import { ChevronDownIcon, InfoIcon } from '../../../lib/ui/icons/icons';
+import { Tooltip } from '../../../lib/ui/tooltip';
+import { isPrimaryExpectedOutcomeMissing } from '../../../lib/test-cases/test-case-validation';
+
+const MANDATORY_FIELD_MESSAGE = 'This field is mandatory';
 
 export type ExpectedOutcomeChangeDetail = {
   testCaseId: string;
@@ -25,6 +30,9 @@ interface ExpectedOutcomeRendererProps {
     e: CustomEvent<ExpectedOutcomeChangeDetail>,
   ) => void;
 }
+
+const EVALUATION_APPROACH_HELP =
+  "How this value is compared against the model's response.";
 
 export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendererProps> = ({
   testCaseId,
@@ -47,7 +55,8 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
   ): SelectConfig => ({
     name: `expectedOutcomeEvaluation-${index}`,
     fieldType: FormFieldType.SELECT,
-    label: 'Evaluation Approach',
+    ariaLabel: 'Evaluation approach',
+    compact: true,
     placeholder: 'Select evaluation approach…',
     required: true,
     optionList,
@@ -114,6 +123,36 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
     );
   };
 
+  const renderThresholdInput = (
+    field: ExpectedOutcomeField,
+    index: number,
+  ) => {
+    const approach = field.evaluationParameters?.approach;
+
+    if (!approach || approach === EvaluationApproach.EXACT) {
+      return null;
+    }
+
+    const defaultThreshold = getDefaultPassScoreForApproach(approach);
+    return (
+      <threshold-input
+        inputId={`expectedOutcomeThreshold-${index}`}
+        label="Threshold"
+        compact
+        value={field.evaluationParameters?.threshold}
+        defaultValue={defaultThreshold}
+        onThresholdChange={(e) =>
+          emit({
+            testCaseId,
+            index,
+            operation: 'set-evaluation-threshold',
+            value: e.detail.value,
+          })
+        }
+      />
+    );
+  };
+
   const renderEvaluationSourceSelector = (
     field: ExpectedOutcomeField,
     index: number,
@@ -159,34 +198,6 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
     );
   };
 
-  const renderThresholdInput = (
-    field: ExpectedOutcomeField,
-    index: number,
-  ) => {
-    const approach = field.evaluationParameters?.approach;
-
-    if (!approach || approach === EvaluationApproach.EXACT) {
-      return null;
-    }
-
-    const defaultThreshold = getDefaultPassScoreForApproach(approach);
-    return (
-      <threshold-input
-        inputId={`expectedOutcomeThreshold-${index}`}
-        value={field.evaluationParameters?.threshold}
-        defaultValue={defaultThreshold}
-        onThresholdChange={(e) =>
-          emit({
-            testCaseId,
-            index,
-            operation: 'set-evaluation-threshold',
-            value: e.detail.value,
-          })
-        }
-      />
-    );
-  };
-
   const renderCriteriaInput = (
     field: ExpectedOutcomeField,
     index: number,
@@ -209,174 +220,268 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
     );
   };
 
-  const renderEvaluationOptions = (field: ExpectedOutcomeField, index: number) => (
-    <details class="expected-outcome-renderer__options">
-      <summary class="expected-outcome-renderer__options-summary">
-        More options
-      </summary>
-      <div class="expected-outcome-renderer__options-content">
-        {renderEvaluationSelector(field, index)}
-        {renderThresholdInput(field, index)}
-        {renderEvaluationSourceSelector(field, index)}
-        {renderCriteriaInput(field, index)}
+  /** Advanced, rarely-touched config (evaluation source/extractor, LLM-judge
+   * criteria) — tucked behind its own disclosure so the card header can stay
+   * to just approach + threshold. */
+  const renderAdvancedOptions = (field: ExpectedOutcomeField, index: number) => {
+    const sourceSelector = renderEvaluationSourceSelector(field, index);
+    const criteriaInput = renderCriteriaInput(field, index);
+    if (!sourceSelector && !criteriaInput) return null;
+
+    return (
+      <details class="expected-outcome-renderer__options">
+        <summary class="expected-outcome-renderer__options-summary">
+          More options
+        </summary>
+        <div class="expected-outcome-renderer__options-content">
+          {sourceSelector}
+          {criteriaInput}
+        </div>
+      </details>
+    );
+  };
+
+  const renderFieldBody = (
+    field: ExpectedOutcomeField,
+    index: number,
+    isPrimary: boolean,
+  ) => {
+    if (field.type === 'textarea') {
+      const isDynamic =
+        dynamicResolutionSupported && field.outcomeMode === 'dynamic';
+      const isMissing =
+        isPrimary && isPrimaryExpectedOutcomeMissing([field]);
+      const config: TextAreaConfig = {
+        name: `expectedOutcome-${index}`,
+        fieldType: FormFieldType.TEXT_AREA,
+        placeholder: isDynamic ? 'Resolved on run' : field.placeholder,
+        required: !isDynamic,
+        readOnly: isDynamic,
+        invalid: isMissing,
+        helpText: isDynamic
+          ? 'Filled automatically when the test is run'
+          : undefined,
+        rows: field.rows || 3,
+        // The copy button renders in the card header instead of here, since
+        // the header already carries the field's label.
+        is_copyable: false,
+      };
+      return (
+        <div class="expected-outcome-renderer__card-body">
+          <app-textarea
+            config={config}
+            value={field.value}
+            onValueChange={(e) =>
+              emit({
+                testCaseId,
+                index,
+                operation: 'set-value',
+                value: e.detail.value,
+              })
+            }
+          />
+          {isMissing && (
+            <p class="expected-outcome-renderer__mandatory-message">
+              {MANDATORY_FIELD_MESSAGE}
+            </p>
+          )}
+          {dynamicResolutionSupported && (
+            <app-select
+              config={buildOutcomeModeConfig(index)}
+              value={field.outcomeMode || 'static'}
+              onValueChange={(e) =>
+                emit({
+                  testCaseId,
+                  index,
+                  operation: 'set-outcome-mode',
+                  value: e.detail.value as ExpectedOutcomeMode,
+                })
+              }
+            />
+          )}
+          {dynamicResolutionSupported && field.outcomeMode === 'dynamic' && (
+            <app-textarea
+              config={buildResolutionQueryConfig(index)}
+              value={field.resolutionQuery || ''}
+              onValueChange={(e) =>
+                emit({
+                  testCaseId,
+                  index,
+                  operation: 'set-resolution-query',
+                  value: e.detail.value,
+                })
+              }
+            />
+          )}
+        </div>
+      );
+    }
+
+    if (field.type === 'chips-input') {
+      const isMissing =
+        isPrimary && isPrimaryExpectedOutcomeMissing([field]);
+      const config: ChipsConfig = {
+        name: `expectedOutcome-${index}`,
+        fieldType: FormFieldType.CHIPS,
+        placeholder: field.placeholder,
+        required: true,
+      };
+
+      return (
+        <div class="expected-outcome-renderer__card-body">
+          <div
+            class={{
+              'expected-outcome-renderer__chips-wrap': true,
+              'expected-outcome-renderer__chips-wrap--invalid': isMissing,
+            }}
+          >
+            <app-chips
+              config={config}
+              value={field.value}
+              onAddChip={(e) =>
+                emit({
+                  testCaseId,
+                  index,
+                  operation: 'add-chip',
+                  value: e.detail.value,
+                })
+              }
+              onRemoveChip={(e) =>
+                emit({
+                  testCaseId,
+                  index,
+                  operation: 'remove-chip',
+                  value: e.detail.value,
+                })
+              }
+            />
+          </div>
+          {isMissing && (
+            <p class="expected-outcome-renderer__mandatory-message">
+              {MANDATORY_FIELD_MESSAGE}
+            </p>
+          )}
+        </div>
+      );
+    }
+
+    if (field.type === 'select') {
+      const config: SelectConfig = {
+        name: `expectedOutcome-${index}`,
+        fieldType: FormFieldType.SELECT,
+        placeholder: field.placeholder,
+        required: true,
+        optionList: field.options,
+      };
+
+      return (
+        <div class="expected-outcome-renderer__card-body">
+          <app-select
+            config={config}
+            value={field.value}
+            onValueChange={(e) =>
+              emit({
+                testCaseId,
+                index,
+                operation: 'set-value',
+                value: e.detail.value,
+              })
+            }
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div class="expected-outcome-renderer__card-body">
+        <input
+          class="expected-outcome-renderer__text-input"
+          type="text"
+          value={field.value}
+          placeholder={field.placeholder}
+          aria-label={field.label}
+          onInput={(e) =>
+            emit({
+              testCaseId,
+              index,
+              operation: 'set-value',
+              value: (e.target as HTMLInputElement).value,
+            })
+          }
+        />
       </div>
-    </details>
+    );
+  };
+
+  const renderFieldSections = (
+    field: ExpectedOutcomeField,
+    index: number,
+    isPrimary: boolean,
+  ) => {
+    const isDynamic =
+      dynamicResolutionSupported && field.type === 'textarea' && field.outcomeMode === 'dynamic';
+
+    return [
+      <div class="expected-outcome-renderer__card-header">
+        <span class="expected-outcome-renderer__card-title">
+          {field.label}
+        </span>
+        {!isDynamic && (
+          <div class="expected-outcome-renderer__card-controls">
+            {field.type === 'textarea' && (
+              <copy-button value={field.value} label={`Copy ${field.label}`} />
+            )}
+            <Tooltip content={EVALUATION_APPROACH_HELP} class="expected-outcome-renderer__info-icon">
+              <InfoIcon />
+            </Tooltip>
+            {renderEvaluationSelector(field, index)}
+            {renderThresholdInput(field, index)}
+          </div>
+        )}
+      </div>,
+      renderFieldBody(field, index, isPrimary),
+      !isDynamic && renderAdvancedOptions(field, index),
+    ];
+  };
+
+  /** The first field — always visible, sharing one outer card with the
+   * "More Options" disclosure below it (not a card of its own). It's also
+   * the only field that gates Run — see isPrimaryExpectedOutcomeMissing. */
+  const renderPrimarySection = (field: ExpectedOutcomeField, index: number) => (
+    <div class="expected-outcome-renderer__primary">
+      {renderFieldSections(field, index, true)}
+    </div>
   );
+
+  /** Every field after the first — rendered as its own bordered card inside
+   * the shared "More Options" tray. */
+  const renderSecondaryCard = (field: ExpectedOutcomeField, index: number) => (
+    <div class="expected-outcome-renderer__card" key={`${field.label}-${index}`}>
+      {renderFieldSections(field, index, false)}
+    </div>
+  );
+
+  const [primaryField, ...secondaryFields] = fields || [];
 
   return (
     <div class="expected-outcome-renderer">
-      {(fields || []).map((field, index) => {
-        if (field.type === 'textarea') {
-          const isDynamic =
-            dynamicResolutionSupported && field.outcomeMode === 'dynamic';
-          const config: TextAreaConfig = {
-            name: `expectedOutcome-${index}`,
-            fieldType: FormFieldType.TEXT_AREA,
-            label: field.label,
-            placeholder: isDynamic ? 'Resolved on run' : field.placeholder,
-            required: !isDynamic,
-            readOnly: isDynamic,
-            helpText: isDynamic
-              ? 'Filled automatically when the test is run'
-              : undefined,
-            rows: field.rows || 2,
-            is_copyable: true,
-          };
-          return (
-            <div class="expected-outcome-renderer__group">
-              <app-textarea
-                config={config}
-                value={field.value}
-                onValueChange={(e) =>
-                  emit({
-                    testCaseId,
-                    index,
-                    operation: 'set-value',
-                    value: e.detail.value,
-                  })
-                }
-              />
-              {dynamicResolutionSupported && (
-                <app-select
-                  config={buildOutcomeModeConfig(index)}
-                  value={field.outcomeMode || 'static'}
-                  onValueChange={(e) =>
-                    emit({
-                      testCaseId,
-                      index,
-                      operation: 'set-outcome-mode',
-                      value: e.detail.value as ExpectedOutcomeMode,
-                    })
-                  }
-                />
-              )}
-              {dynamicResolutionSupported &&
-                field.outcomeMode === 'dynamic' && (
-                  <app-textarea
-                    config={buildResolutionQueryConfig(index)}
-                    value={field.resolutionQuery || ''}
-                    onValueChange={(e) =>
-                      emit({
-                        testCaseId,
-                        index,
-                        operation: 'set-resolution-query',
-                        value: e.detail.value,
-                      })
-                    }
-                  />
-                )}
-              {!isDynamic && renderEvaluationOptions(field, index)}
-            </div>
-          );
-        }
+      {primaryField && (
+        <div class="expected-outcome-renderer__outer-card">
+          {renderPrimarySection(primaryField, 0)}
 
-        if (field.type === 'chips-input') {
-          const config: ChipsConfig = {
-            name: `expectedOutcome-${index}`,
-            fieldType: FormFieldType.CHIPS,
-            label: field.label,
-            placeholder: field.placeholder,
-            required: true,
-          };
-
-          return (
-            <div class="expected-outcome-renderer__group">
-              <app-chips
-                config={config}
-                value={field.value}
-                onAddChip={(e) =>
-                  emit({
-                    testCaseId,
-                    index,
-                    operation: 'add-chip',
-                    value: e.detail.value,
-                  })
-                }
-                onRemoveChip={(e) =>
-                  emit({
-                    testCaseId,
-                    index,
-                    operation: 'remove-chip',
-                    value: e.detail.value,
-                  })
-                }
-              />
-              {renderEvaluationOptions(field, index)}
-            </div>
-          );
-        }
-
-        if (field.type === 'select') {
-          const config: SelectConfig = {
-            name: `expectedOutcome-${index}`,
-            fieldType: FormFieldType.SELECT,
-            label: field.label,
-            placeholder: field.placeholder,
-            required: true,
-            optionList: field.options,
-          };
-
-          return (
-            <div class="expected-outcome-renderer__group">
-              <app-select
-                config={config}
-                value={field.value}
-                onValueChange={(e) =>
-                  emit({
-                    testCaseId,
-                    index,
-                    operation: 'set-value',
-                    value: e.detail.value,
-                  })
-                }
-              />
-              {renderEvaluationOptions(field, index)}
-            </div>
-          );
-        }
-
-        return (
-          <div class="expected-outcome-renderer__group">
-            <div class="expected-outcome-renderer__text">
-              <label>{field.label}</label>
-              <input
-                type="text"
-                value={field.value}
-                placeholder={field.placeholder}
-                onInput={(e) =>
-                  emit({
-                    testCaseId,
-                    index,
-                    operation: 'set-value',
-                    value: (e.target as HTMLInputElement).value,
-                  })
-                }
-              />
-            </div>
-            {renderEvaluationOptions(field, index)}
-          </div>
-        );
-      })}
+          {secondaryFields.length > 0 && (
+            <details class="expected-outcome-renderer__more-options">
+              <summary class="expected-outcome-renderer__more-options-summary">
+                <ChevronDownIcon class="expected-outcome-renderer__more-options-chevron" />
+                More Options
+              </summary>
+              <div class="expected-outcome-renderer__more-options-content">
+                {secondaryFields.map((field, i) => renderSecondaryCard(field, i + 1))}
+              </div>
+            </details>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
+++ b/src/components/llm-test-runner/test-cases/expected-outcome-renderer.tsx
@@ -220,9 +220,6 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
     );
   };
 
-  /** Advanced, rarely-touched config (evaluation source/extractor, LLM-judge
-   * criteria) — tucked behind its own disclosure so the card header can stay
-   * to just approach + threshold. */
   const renderAdvancedOptions = (field: ExpectedOutcomeField, index: number) => {
     const sourceSelector = renderEvaluationSourceSelector(field, index);
     const criteriaInput = renderCriteriaInput(field, index);
@@ -444,17 +441,13 @@ export const ExpectedOutcomeRenderer: FunctionalComponent<ExpectedOutcomeRendere
     ];
   };
 
-  /** The first field — always visible, sharing one outer card with the
-   * "More Options" disclosure below it (not a card of its own). It's also
-   * the only field that gates Run — see isPrimaryExpectedOutcomeMissing. */
+  // Only the primary field gates Run — see isPrimaryExpectedOutcomeMissing.
   const renderPrimarySection = (field: ExpectedOutcomeField, index: number) => (
     <div class="expected-outcome-renderer__primary">
       {renderFieldSections(field, index, true)}
     </div>
   );
 
-  /** Every field after the first — rendered as its own bordered card inside
-   * the shared "More Options" tray. */
   const renderSecondaryCard = (field: ExpectedOutcomeField, index: number) => (
     <div class="expected-outcome-renderer__card" key={`${field.label}-${index}`}>
       {renderFieldSections(field, index, false)}

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.css
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.css
@@ -262,108 +262,15 @@
  * input-content > textarea / chat-history / expected-outcome layout). */
 .test-case-row__input-content {
   flex: 1;
-  padding: var(--spacing-5);
+  padding: var(--spacing-8);
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-3);
+  gap: var(--spacing-5);
 }
 
 /* The Run footer that used to live at the bottom of the input column is
  * removed — the Run button is now in the summary, always reachable
  * without expanding the card. */
-
-/* ------------------------------------------------------------------ */
-/* Expected outcome renderer (within input column)                    */
-/* ------------------------------------------------------------------ */
-
-.expected-outcome-renderer {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-3);
-  margin-top: var(--spacing-2);
-}
-
-.expected-outcome-renderer__group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-2);
-  padding: var(--spacing-3);
-  border: var(--border-width) solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--background);
-  transition: border-color 150ms ease;
-}
-
-.expected-outcome-renderer__group:focus-within {
-  border-color: var(--border-strong);
-}
-
-.expected-outcome-renderer__options {
-  border: var(--border-width) solid var(--border);
-  border-radius: var(--radius-lg);
-  background: transparent;
-  overflow: hidden;
-  transition: border-color 150ms ease, background-color 150ms ease;
-}
-
-.expected-outcome-renderer__options[open] {
-  background: var(--muted);
-  border-color: var(--border-strong);
-}
-
-.expected-outcome-renderer__options-summary {
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 11px;
-  font-weight: var(--font-weight-semibold);
-  text-transform: uppercase;
-  letter-spacing: var(--letter-spacing-wider);
-  color: var(--muted-foreground);
-  padding: var(--spacing-3) var(--spacing-3);
-  user-select: none;
-  list-style: none;
-  transition: color 150ms ease;
-}
-
-.expected-outcome-renderer__options-summary:hover {
-  color: var(--foreground);
-}
-
-.expected-outcome-renderer__options-summary::-webkit-details-marker {
-  display: none;
-}
-
-.expected-outcome-renderer__options-summary::marker {
-  display: none;
-  content: '';
-}
-
-.expected-outcome-renderer__options-summary::before {
-  content: '';
-  display: inline-block;
-  width: 0;
-  height: 0;
-  border-top: 4px solid transparent;
-  border-bottom: 4px solid transparent;
-  border-left: 5px solid currentColor;
-  transition: transform 200ms ease;
-  transform-origin: 25% 50%;
-  flex-shrink: 0;
-}
-
-.expected-outcome-renderer__options[open]
-  .expected-outcome-renderer__options-summary::before {
-  transform: rotate(90deg);
-}
-
-.expected-outcome-renderer__options-content {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-3);
-  padding: 0 var(--spacing-3) var(--spacing-3);
-}
 
 /* ------------------------------------------------------------------ */
 /* Responsive                                                         */


### PR DESCRIPTION
## Summary

**3 of 7** in the "D - LLM Test Runner" Figma redesign stack (stacked on #73).

- Redesign the expected-outcome section into a primary card plus a shared "More Options" disclosure for every field after it, using the new `Tooltip` component in place of native `title` attributes and showing a "This field is mandatory" message on an empty primary field.
- Move the section's styles into its own dedicated `expected-outcome-renderer.css` (previously inlined in `llm-test-case-row.css`) and register it via `styleUrls`.
- Increase `.test-case-row__input-content`'s padding to give the new card layout more breathing room.

Note: this PR is ~850 lines rather than the 500-600 ideal — a card redesign this size isn't meaningfully splittable further without shipping half a component mid-stack.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx stencil test --spec --passWithNoTests` — 225/225 passing
- [x] `npx eslint` — clean