### PR TITLE
[4/7] feat(ui): redesign question input + chat history as a modal

### DIFF
--- a/src/components/llm-test-runner/test-cases/chat-history.css
+++ b/src/components/llm-test-runner/test-cases/chat-history.css
@@ -1,112 +1,136 @@
 :host {
-  display: block;
+  display: inline-flex;
 }
 
-/*
- * Chat history is now a disclosure (<details>) — the same pattern as the
- * "More options" panel in the field renderer, so the row has consistent
- * affordances for optional content. Collapsed = enabled false, expanded =
- * enabled true. The textarea value is preserved across collapses so the
- * user can hide it without losing their input.
- */
 .chat-history {
-  border: var(--border-width) solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--background);
-  overflow: hidden;
-  transition: border-color 150ms ease;
+  display: inline-flex;
 }
 
-.chat-history[open] {
-  border-color: var(--border-strong);
-}
-
-.chat-history:focus-within {
-  border-color: var(--border-strong);
-}
-
-.chat-history__summary {
-  cursor: pointer;
-  display: flex;
+/* Collapsed: a plain 32×32 icon button. Highlighted once chat history has
+ * been saved, so the row shows at a glance that it's in use. */
+.chat-history__trigger {
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
-  font-size: 11px;
-  font-weight: var(--font-weight-semibold);
-  text-transform: uppercase;
-  letter-spacing: var(--letter-spacing-wider);
-  color: var(--muted-foreground);
-  user-select: none;
-  list-style: none;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-md);
   background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
   transition: color 150ms ease, background-color 150ms ease;
 }
 
-.chat-history__summary:hover {
+.chat-history__trigger:hover {
   color: var(--foreground);
   background: var(--muted);
 }
 
-.chat-history[open] .chat-history__summary {
-  color: var(--foreground);
-  border-bottom: var(--border-width) solid var(--border);
-  background: var(--muted);
-}
-
-/* Hide native disclosure markers — we draw a custom chevron via ::before. */
-.chat-history__summary::-webkit-details-marker {
-  display: none;
-}
-
-.chat-history__summary::marker {
-  display: none;
-  content: '';
-}
-
-/* Custom chevron — rotates 90° on open, matching the More options panel. */
-.chat-history__summary::before {
-  content: '';
-  display: inline-block;
-  width: 0;
-  height: 0;
-  border-top: 4px solid transparent;
-  border-bottom: 4px solid transparent;
-  border-left: 5px solid currentColor;
-  transition: transform 200ms ease;
-  transform-origin: 25% 50%;
-  flex-shrink: 0;
-}
-
-.chat-history[open] .chat-history__summary::before {
-  transform: rotate(90deg);
+.chat-history__trigger--active {
+  background: var(--ring-soft);
+  color: var(--ring);
 }
 
 .chat-history__icon {
-  flex-shrink: 0;
-  /* Slight muting so the icon doesn't compete with the chevron. */
-  opacity: 0.7;
+  width: 16px;
+  height: 16px;
 }
 
-.chat-history__label {
-  /* Span is stylistic — letter-spacing already comes from the summary. */
+/* ------------------------------------------------------------------ */
+/* Modal                                                               */
+/* ------------------------------------------------------------------ */
+
+.chat-history-modal__backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-5);
+  background: rgb(0 0 0 / 0.4);
+  z-index: var(--z-modal);
 }
 
-.chat-history__content {
-  padding: 0;
-  background: var(--background);
-}
-
-.chat-history__textarea {
+.chat-history-modal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
   width: 100%;
-  box-sizing: border-box;
-  padding: var(--spacing-2) var(--spacing-3);
-  border: none;
-  font-family: var(--font-family-mono);
+  max-width: 560px;
+  max-height: calc(100vh - var(--spacing-8) * 2);
+  padding: var(--spacing-6) var(--spacing-8);
+  background: var(--background);
+  border-radius: var(--radius-3xl);
+  box-shadow: var(--shadow-lg);
+  overflow-y: auto;
+}
+
+.chat-history-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+}
+
+.chat-history-modal__title {
+  margin: 0;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-medium);
+  color: var(--foreground);
+}
+
+.chat-history-modal__subtitle {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--muted-foreground);
+}
+
+.chat-history-modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.chat-history-modal__label {
   font-size: var(--font-size-xs);
-  line-height: 1.55;
-  resize: vertical;
-  min-height: 8rem;
+  font-weight: var(--font-weight-medium);
+  color: var(--foreground);
+}
+
+.chat-history-modal__textarea {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 220px;
+  padding: var(--spacing-3);
+  border: var(--border-width) solid var(--input);
+  border-radius: var(--radius-lg);
   background: var(--background);
   color: var(--foreground);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  line-height: 1.55;
+  resize: vertical;
   outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.chat-history-modal__textarea:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 4px var(--ring-soft);
+}
+
+.chat-history-modal__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--spacing-2);
+}
+
+@media (max-width: 640px) {
+  .chat-history-modal {
+    padding: var(--spacing-5);
+    gap: var(--spacing-5);
+  }
 }

--- a/src/components/llm-test-runner/test-cases/chat-history.css
+++ b/src/components/llm-test-runner/test-cases/chat-history.css
@@ -6,8 +6,7 @@
   display: inline-flex;
 }
 
-/* Collapsed: a plain 32×32 icon button. Highlighted once chat history has
- * been saved, so the row shows at a glance that it's in use. */
+/* Highlighted once chat history has been saved, so it reads as in-use at a glance. */
 .chat-history__trigger {
   display: inline-flex;
   align-items: center;
@@ -37,10 +36,6 @@
   width: 16px;
   height: 16px;
 }
-
-/* ------------------------------------------------------------------ */
-/* Modal                                                               */
-/* ------------------------------------------------------------------ */
 
 .chat-history-modal__backdrop {
   position: fixed;

--- a/src/components/llm-test-runner/test-cases/chat-history.spec.tsx
+++ b/src/components/llm-test-runner/test-cases/chat-history.spec.tsx
@@ -4,33 +4,26 @@ import { ChatHistory, type ChatHistoryChangeDetail } from './chat-history';
 
 type SpecPage = Awaited<ReturnType<typeof newSpecPage>>;
 
-type ChatHistoryHost = HTMLElement & {
-  chatHistoryEnabled: boolean;
-  chatHistoryValue: string;
-};
-
-function attachControlledParent(page: SpecPage): void {
-  page.root.addEventListener('chatHistoryChange', (e: Event) => {
-    const { enabled, value } = (e as CustomEvent<ChatHistoryChangeDetail>)
-      .detail;
-    const host = page.root as ChatHistoryHost;
-    host.chatHistoryEnabled = enabled;
-    host.chatHistoryValue = value;
-  });
+function getTrigger(page: SpecPage): HTMLButtonElement {
+  return page.root.shadowRoot.querySelector(
+    '.chat-history__trigger',
+  ) as HTMLButtonElement;
 }
 
-/**
- * Native <details> doesn't fire `toggle` from a programmatic `.open = ...`
- * change in jsdom; we trigger it explicitly so the component's onToggle
- * handler observes the new state, just as it would in a real browser.
- */
-async function openChatHistoryAsUser(page: SpecPage): Promise<void> {
-  attachControlledParent(page);
-  const details = page.root.shadowRoot!.querySelector(
-    'details',
-  ) as HTMLDetailsElement;
-  details.open = true;
-  details.dispatchEvent(new Event('toggle', { bubbles: true }));
+function getTextarea(page: SpecPage): HTMLTextAreaElement | null {
+  return page.root.shadowRoot.querySelector(
+    '.chat-history-modal__textarea',
+  ) as HTMLTextAreaElement | null;
+}
+
+function getBackdrop(page: SpecPage): HTMLElement | null {
+  return page.root.shadowRoot.querySelector(
+    '.chat-history-modal__backdrop',
+  ) as HTMLElement | null;
+}
+
+async function openModal(page: SpecPage): Promise<void> {
+  getTrigger(page).click();
   await page.waitForChanges();
 }
 
@@ -42,12 +35,17 @@ function getTextareaValue(textarea: HTMLTextAreaElement): string {
   return textarea.getAttribute('value') ?? '';
 }
 
-// Stencil's spec DOM doesn't reflect the `open` property on <details> the
-// way real browsers do. Read the attribute (set by the JSX `open={...}`
-// binding) instead.
-function isDetailsOpen(details: HTMLDetailsElement): boolean {
-  if (typeof details.open === 'boolean') return details.open;
-  return details.hasAttribute('open');
+function setTextareaValue(textarea: HTMLTextAreaElement, value: string): void {
+  textarea.value = value;
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function clickButtonWithText(page: SpecPage, text: string): void {
+  const buttons = Array.from(
+    page.root.shadowRoot.querySelectorAll('.chat-history-modal__footer button'),
+  ) as HTMLButtonElement[];
+  const button = buttons.find(b => b.textContent?.trim() === text);
+  button?.click();
 }
 
 describe('ChatHistory', () => {
@@ -55,140 +53,160 @@ describe('ChatHistory', () => {
     jest.clearAllMocks();
   });
 
-  it('renders open with textarea value from props when enabled', async () => {
+  it('renders a collapsed icon-only trigger with no modal open by default', async () => {
     const page = await newSpecPage({
       components: [ChatHistory],
-      html: '<chat-history chat-history-enabled chat-history-value="[imported]"></chat-history>',
+      html: '<chat-history></chat-history>',
     });
 
-    await page.waitForChanges();
+    expect(getTrigger(page)).not.toBeNull();
+    expect(getBackdrop(page)).toBeNull();
+  });
 
-    const details = page.root.shadowRoot.querySelector(
-      'details',
-    ) as HTMLDetailsElement;
-    expect(isDetailsOpen(details)).toBe(true);
+  it('opens the modal with the current value when the trigger is clicked', async () => {
+    const page = await newSpecPage({
+      components: [ChatHistory],
+      html: '<chat-history chat-history-value="[imported]"></chat-history>',
+    });
 
-    const textarea = page.root.shadowRoot.querySelector(
-      '.chat-history__textarea',
-    ) as HTMLTextAreaElement;
+    await openModal(page);
+
+    expect(getBackdrop(page)).not.toBeNull();
+    const textarea = getTextarea(page);
     expect(textarea).not.toBeNull();
-    expect(getTextareaValue(textarea)).toBe('[imported]');
+    expect(getTextareaValue(textarea!)).toBe('[imported]');
   });
 
-  it('renders collapsed (open=false) by default', async () => {
+  it('does not emit chatHistoryChange while typing — only on Save', async () => {
     const page = await newSpecPage({
       components: [ChatHistory],
       html: '<chat-history></chat-history>',
     });
-
-    const details = page.root.shadowRoot.querySelector(
-      'details',
-    ) as HTMLDetailsElement;
-    expect(isDetailsOpen(details)).toBe(false);
-  });
-
-  it('shows the summary label and chat icon at all times', async () => {
-    const page = await newSpecPage({
-      components: [ChatHistory],
-      html: '<chat-history></chat-history>',
-    });
-
-    const summary = page.root.shadowRoot.querySelector(
-      '.chat-history__summary',
-    );
-    expect(summary).not.toBeNull();
-    expect(summary?.textContent).toContain('Chat history');
-    expect(
-      page.root.shadowRoot.querySelector('.chat-history__icon'),
-    ).not.toBeNull();
-  });
-
-  it('opens to reveal the textarea after the user expands the disclosure', async () => {
-    const page = await newSpecPage({
-      components: [ChatHistory],
-      html: '<chat-history></chat-history>',
-    });
-
-    await openChatHistoryAsUser(page);
-
-    expect(
-      page.root.shadowRoot.querySelector('.chat-history__textarea'),
-    ).not.toBeNull();
-  });
-
-  it('emits chatHistoryChange with enabled=true when the user expands', async () => {
-    const page = await newSpecPage({
-      components: [ChatHistory],
-      html: '<chat-history></chat-history>',
-    });
+    await openModal(page);
 
     const spy = jest.fn();
     page.root.addEventListener('chatHistoryChange', (e: Event) =>
       spy((e as CustomEvent<ChatHistoryChangeDetail>).detail),
     );
 
-    const details = page.root.shadowRoot.querySelector(
-      'details',
-    ) as HTMLDetailsElement;
-    details.open = true;
-    details.dispatchEvent(new Event('toggle', { bubbles: true }));
+    setTextareaValue(getTextarea(page)!, 'hello');
     await page.waitForChanges();
 
-    expect(spy).toHaveBeenCalledWith({ enabled: true, value: '' });
+    expect(spy).not.toHaveBeenCalled();
   });
 
-  it('emits chatHistoryChange when the user types in the textarea', async () => {
+  it('emits chatHistoryChange with enabled=true and closes the modal on Save', async () => {
     const page = await newSpecPage({
       components: [ChatHistory],
       html: '<chat-history></chat-history>',
     });
-
-    await openChatHistoryAsUser(page);
+    await openModal(page);
 
     const spy = jest.fn();
     page.root.addEventListener('chatHistoryChange', (e: Event) =>
       spy((e as CustomEvent<ChatHistoryChangeDetail>).detail),
     );
-    spy.mockClear();
 
-    const textarea = page.root.shadowRoot.querySelector(
-      '.chat-history__textarea',
-    ) as HTMLTextAreaElement;
-    textarea.value = 'hello';
-    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    setTextareaValue(getTextarea(page)!, 'hello');
+    clickButtonWithText(page, 'Save');
     await page.waitForChanges();
 
     expect(spy).toHaveBeenCalledWith({ enabled: true, value: 'hello' });
+    expect(getBackdrop(page)).toBeNull();
   });
 
-  it('preserves typed value across collapse/expand toggles', async () => {
+  it('emits enabled=false when saving an empty value', async () => {
     const page = await newSpecPage({
       components: [ChatHistory],
-      html: '<chat-history></chat-history>',
+      html: '<chat-history chat-history-enabled chat-history-value="keep me"></chat-history>',
     });
-
-    await openChatHistoryAsUser(page);
-
-    const textarea = page.root.shadowRoot.querySelector(
-      '.chat-history__textarea',
-    ) as HTMLTextAreaElement;
-    textarea.value = 'keep me';
-    textarea.dispatchEvent(new Event('input', { bubbles: true }));
-    await page.waitForChanges();
+    await openModal(page);
 
     const spy = jest.fn();
     page.root.addEventListener('chatHistoryChange', (e: Event) =>
       spy((e as CustomEvent<ChatHistoryChangeDetail>).detail),
     );
 
-    // User collapses — emit enabled=false but value is preserved.
-    const details = page.root.shadowRoot.querySelector(
-      'details',
-    ) as HTMLDetailsElement;
-    details.open = false;
-    details.dispatchEvent(new Event('toggle', { bubbles: true }));
+    setTextareaValue(getTextarea(page)!, '   ');
+    clickButtonWithText(page, 'Save');
     await page.waitForChanges();
 
-    expect(spy).toHaveBeenCalledWith({ enabled: false, value: 'keep me' });
+    expect(spy).toHaveBeenCalledWith({ enabled: false, value: '   ' });
+  });
+
+  it('discards the draft and does not emit an event on Cancel', async () => {
+    const page = await newSpecPage({
+      components: [ChatHistory],
+      html: '<chat-history chat-history-value="saved"></chat-history>',
+    });
+    await openModal(page);
+
+    setTextareaValue(getTextarea(page)!, 'unsaved edit');
+
+    const spy = jest.fn();
+    page.root.addEventListener('chatHistoryChange', (e: Event) =>
+      spy((e as CustomEvent<ChatHistoryChangeDetail>).detail),
+    );
+
+    clickButtonWithText(page, 'Cancel');
+    await page.waitForChanges();
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(getBackdrop(page)).toBeNull();
+
+    // Reopening shows the original saved value, not the discarded edit.
+    await openModal(page);
+    expect(getTextareaValue(getTextarea(page)!)).toBe('saved');
+  });
+
+  it('closes without saving when the close (X) button is clicked', async () => {
+    const page = await newSpecPage({
+      components: [ChatHistory],
+      html: '<chat-history></chat-history>',
+    });
+    await openModal(page);
+
+    const spy = jest.fn();
+    page.root.addEventListener('chatHistoryChange', (e: Event) =>
+      spy((e as CustomEvent<ChatHistoryChangeDetail>).detail),
+    );
+
+    const closeButton = page.root.shadowRoot.querySelector(
+      '.chat-history-modal__header button',
+    ) as HTMLButtonElement;
+    closeButton.click();
+    await page.waitForChanges();
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(getBackdrop(page)).toBeNull();
+  });
+
+  it('closes without saving when Escape is pressed', async () => {
+    const page = await newSpecPage({
+      components: [ChatHistory],
+      html: '<chat-history></chat-history>',
+    });
+    await openModal(page);
+
+    getBackdrop(page)!.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+    await page.waitForChanges();
+
+    expect(getBackdrop(page)).toBeNull();
+  });
+
+  it('closes without saving when the backdrop is clicked directly', async () => {
+    const page = await newSpecPage({
+      components: [ChatHistory],
+      html: '<chat-history></chat-history>',
+    });
+    await openModal(page);
+
+    const backdrop = getBackdrop(page)!;
+    backdrop.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await page.waitForChanges();
+
+    expect(getBackdrop(page)).toBeNull();
   });
 });

--- a/src/components/llm-test-runner/test-cases/chat-history.tsx
+++ b/src/components/llm-test-runner/test-cases/chat-history.tsx
@@ -1,4 +1,7 @@
-import { Component, Event, EventEmitter, Prop, h } from '@stencil/core';
+import { Component, Event, EventEmitter, Prop, State, h } from '@stencil/core';
+import { Button } from '../../../lib/ui/button/index';
+import { IconButton } from '../../../lib/ui/icon-button/index';
+import { FileClockIcon, XIcon } from '../../../lib/ui/icons/icons';
 
 const CHAT_HISTORY_PLACEHOLDER = `[
   {"role": "user", "content": "How do I import a saved suite?"},
@@ -12,74 +15,122 @@ export type ChatHistoryChangeDetail = {
 
 @Component({
   tag: 'chat-history',
-  styleUrl: 'chat-history.css',
+  styleUrls: [
+    'chat-history.css',
+    '../../../lib/ui/button/button.css',
+    '../../../lib/ui/icon-button/icon-button.css',
+  ],
   shadow: true,
 })
 export class ChatHistory {
-  @Prop() chatHistoryEnabled = false;
+  @Prop({ reflect: true }) chatHistoryEnabled = false;
   @Prop() chatHistoryValue = '';
 
   @Event({ bubbles: true, composed: true })
   chatHistoryChange: EventEmitter<ChatHistoryChangeDetail>;
 
-  private emit(detail: ChatHistoryChangeDetail) {
-    this.chatHistoryChange.emit(detail);
-  }
+  /** Local draft — edits only take effect once the user clicks Save. */
+  @State() isOpen = false;
+  @State() draft = '';
 
-  /**
-   * Native <details> fires `toggle` whenever its open state changes — both
-   * via user click on the summary AND from programmatic / prop-driven sync.
-   * We treat "open" as the source of truth for `enabled` and preserve the
-   * textarea value across collapses, so the user can quickly hide chat
-   * history without losing what they typed.
-   */
-  private onToggle = (e: Event) => {
-    const open = (e.target as HTMLDetailsElement).open;
-    if (open !== this.chatHistoryEnabled) {
-      this.emit({ enabled: open, value: this.chatHistoryValue });
-    }
+  private openModal = () => {
+    this.draft = this.chatHistoryValue;
+    this.isOpen = true;
   };
 
-  private onTextInput = (e: Event) => {
-    const value = (e.target as HTMLTextAreaElement).value;
-    this.emit({ enabled: this.chatHistoryEnabled, value });
+  private closeModal = () => {
+    this.isOpen = false;
+  };
+
+  private handleSave = () => {
+    const value = this.draft;
+    this.chatHistoryChange.emit({ enabled: value.trim().length > 0, value });
+    this.isOpen = false;
+  };
+
+  private handleDraftInput = (e: Event) => {
+    this.draft = (e.target as HTMLTextAreaElement).value;
+  };
+
+  private handleBackdropClick = (e: MouseEvent) => {
+    if (e.target === e.currentTarget) this.closeModal();
+  };
+
+  private handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') this.closeModal();
   };
 
   render() {
     return (
-      <details
-        class="chat-history"
-        open={this.chatHistoryEnabled}
-        onToggle={this.onToggle}
-      >
-        <summary class="chat-history__summary">
-          <svg
-            class="chat-history__icon"
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
+      <div class="chat-history">
+        <button
+          type="button"
+          class={{
+            'chat-history__trigger': true,
+            'chat-history__trigger--active': this.chatHistoryEnabled,
+          }}
+          title="Chat history"
+          aria-label="Chat history"
+          aria-haspopup="dialog"
+          aria-expanded={this.isOpen ? 'true' : 'false'}
+          onClick={this.openModal}
+        >
+          <FileClockIcon class="chat-history__icon" />
+        </button>
+
+        {this.isOpen && (
+          <div
+            class="chat-history-modal__backdrop"
+            onClick={this.handleBackdropClick}
+            onKeyDown={this.handleKeyDown}
           >
-            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-          </svg>
-          <span class="chat-history__label">Chat history</span>
-        </summary>
-        <div class="chat-history__content">
-          <textarea
-            class="chat-history__textarea"
-            value={this.chatHistoryValue}
-            rows={6}
-            placeholder={CHAT_HISTORY_PLACEHOLDER}
-            aria-label="Chat history"
-            onInput={this.onTextInput}
-          />
-        </div>
-      </details>
+            <div
+              class="chat-history-modal"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="chat-history-modal-title"
+            >
+              <div class="chat-history-modal__header">
+                <h2 id="chat-history-modal-title" class="chat-history-modal__title">
+                  Add chat history
+                </h2>
+                <IconButton variant="outline" onClick={this.closeModal} title="Close">
+                  <XIcon />
+                </IconButton>
+              </div>
+
+              <p class="chat-history-modal__subtitle">
+                Add chat history to improve accuracy of the response.
+              </p>
+
+              <div class="chat-history-modal__field">
+                <label class="chat-history-modal__label" htmlFor="chat-history-modal-textarea">
+                  Console
+                </label>
+                <textarea
+                  id="chat-history-modal-textarea"
+                  class="chat-history-modal__textarea"
+                  rows={10}
+                  placeholder={CHAT_HISTORY_PLACEHOLDER}
+                  aria-label="Chat history JSON"
+                  value={this.draft}
+                  autoFocus
+                  onInput={this.handleDraftInput}
+                />
+              </div>
+
+              <div class="chat-history-modal__footer">
+                <Button variant="outline" size="md" onClick={this.closeModal}>
+                  Cancel
+                </Button>
+                <Button variant="primary" size="md" onClick={this.handleSave}>
+                  Save
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
     );
   }
 }

--- a/src/components/llm-test-runner/test-cases/chat-history.tsx
+++ b/src/components/llm-test-runner/test-cases/chat-history.tsx
@@ -29,8 +29,8 @@ export class ChatHistory {
   @Event({ bubbles: true, composed: true })
   chatHistoryChange: EventEmitter<ChatHistoryChangeDetail>;
 
-  /** Local draft — edits only take effect once the user clicks Save. */
   @State() isOpen = false;
+  /** Edits only take effect once the user clicks Save. */
   @State() draft = '';
 
   private openModal = () => {

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.css
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.css
@@ -273,6 +273,96 @@
  * without expanding the card. */
 
 /* ------------------------------------------------------------------ */
+/* Question / prompt input                                            */
+/* ------------------------------------------------------------------ */
+
+.test-case-row__question {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.test-case-row__question-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-lg);
+  color: var(--foreground);
+}
+
+.test-case-row__question-info {
+  display: inline-flex;
+  color: var(--muted-foreground);
+}
+
+.test-case-row__question-info svg {
+  width: 16px;
+  height: 16px;
+}
+
+.test-case-row__question-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-1);
+  width: 100%;
+}
+
+.test-case-row__question-input-wrap {
+  position: relative;
+  flex: 1 1 320px;
+  min-width: 0;
+}
+
+.test-case-row__question-input {
+  width: 100%;
+  box-sizing: border-box;
+  height: 48px;
+  padding: var(--spacing-2) 36px var(--spacing-2) var(--spacing-4);
+  border: var(--border-width) solid var(--input);
+  border-radius: var(--radius-full);
+  background: var(--background);
+  box-shadow: var(--shadow-sm);
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  color: var(--foreground);
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.test-case-row__question-input:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 4px var(--ring-soft);
+}
+
+.test-case-row__question-clear {
+  position: absolute;
+  top: 50%;
+  right: var(--spacing-4);
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+
+.test-case-row__question-clear svg {
+  width: 14px;
+  height: 14px;
+}
+
+.test-case-row__question-clear:hover {
+  color: var(--foreground);
+}
+
+/* ------------------------------------------------------------------ */
 /* Responsive                                                         */
 /* ------------------------------------------------------------------ */
 

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.css
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.css
@@ -268,14 +268,6 @@
   gap: var(--spacing-5);
 }
 
-/* The Run footer that used to live at the bottom of the input column is
- * removed — the Run button is now in the summary, always reachable
- * without expanding the card. */
-
-/* ------------------------------------------------------------------ */
-/* Question / prompt input                                            */
-/* ------------------------------------------------------------------ */
-
 .test-case-row__question {
   display: flex;
   flex-direction: column;

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.tsx
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.tsx
@@ -4,8 +4,14 @@ import { ResponseOutput } from './output/response-output';
 import { EvaluationSummary } from './evaluation/evaluation-summary';
 import { Button } from '../../../lib/ui/button/index';
 import { IconButton } from '../../../lib/ui/icon-button/index';
-import { PlayIcon, SpinnerIcon, TrashIcon } from '../../../lib/ui/icons/icons';
-import { FormFieldType, TextAreaConfig } from '../../../lib/form/schema';
+import { Tooltip } from '../../../lib/ui/tooltip';
+import {
+  InfoIcon,
+  PlayIcon,
+  SpinnerIcon,
+  TrashIcon,
+  XIcon,
+} from '../../../lib/ui/icons/icons';
 import {
   ExpectedOutcomeChangeDetail,
   ExpectedOutcomeRenderer,
@@ -90,16 +96,6 @@ export const LLMTestCaseRow: FunctionalComponent<LLMTestCaseRowProps> = ({
   onExpectedOutcomeChange,
   onChatHistoryChange,
 }) => {
-  const questionConfig: TextAreaConfig = {
-    name: 'question',
-    fieldType: FormFieldType.TEXT_AREA,
-    type: 'text',
-    label: 'Question',
-    placeholder: 'Enter your question here...',
-    required: true,
-    rows: 3,
-  };
-
   const canRun = !!testCase.question.trim();
   const isRunning = testCase.isRunning;
   const status = computeTestStatus(testCase);
@@ -153,36 +149,70 @@ export const LLMTestCaseRow: FunctionalComponent<LLMTestCaseRowProps> = ({
 
       <div class="test-case-row__body">
         <section class="test-case-row__panel test-case-row__panel--input">
-          <header class="test-case-row__panel-header">Input</header>
           <div class="test-case-row__input-content">
-            <app-textarea
-              config={questionConfig}
-              value={testCase.question}
-              onValueChange={(e) =>
-                handleTestCaseChange({
-                  detail: {
-                    testCaseId: testCase.id,
-                    key: 'question',
-                    value: e.detail.value,
-                  },
-                } as CustomEvent<{ testCaseId: string; key: string; value: string }>)
-              }
-            />
-            <chat-history
-              chatHistoryEnabled={testCase.chatHistory?.enabled ?? false}
-              chatHistoryValue={testCase.chatHistory?.value ?? ''}
-              onChatHistoryChange={(e: Event) => {
-                const { enabled, value } = (e as CustomEvent<ChatHistoryChangeDetail>)
-                  .detail;
-                onChatHistoryChange({
-                  detail: {
-                    testCaseId: testCase.id,
-                    enabled,
-                    value,
-                  },
-                } as CustomEvent<ChatHistoryRowChangeDetail>);
-              }}
-            />
+            <div class="test-case-row__question">
+              <span class="test-case-row__question-label">
+                Add your question (prompt)
+                <Tooltip
+                  content="The prompt sent to the model for this test case."
+                  class="test-case-row__question-info"
+                >
+                  <InfoIcon />
+                </Tooltip>
+              </span>
+              <div class="test-case-row__question-row">
+                <div class="test-case-row__question-input-wrap">
+                  <input
+                    type="text"
+                    class="test-case-row__question-input"
+                    placeholder="Enter your question here..."
+                    value={testCase.question}
+                    onInput={(e) =>
+                      handleTestCaseChange({
+                        detail: {
+                          testCaseId: testCase.id,
+                          key: 'question',
+                          value: (e.target as HTMLInputElement).value,
+                        },
+                      } as CustomEvent<{ testCaseId: string; key: string; value: string }>)
+                    }
+                  />
+                  {!!testCase.question && (
+                    <button
+                      type="button"
+                      class="test-case-row__question-clear"
+                      aria-label="Clear question"
+                      onClick={() =>
+                        handleTestCaseChange({
+                          detail: {
+                            testCaseId: testCase.id,
+                            key: 'question',
+                            value: '',
+                          },
+                        } as CustomEvent<{ testCaseId: string; key: string; value: string }>)
+                      }
+                    >
+                      <XIcon />
+                    </button>
+                  )}
+                </div>
+                <chat-history
+                  chatHistoryEnabled={testCase.chatHistory?.enabled ?? false}
+                  chatHistoryValue={testCase.chatHistory?.value ?? ''}
+                  onChatHistoryChange={(e: Event) => {
+                    const { enabled, value } = (e as CustomEvent<ChatHistoryChangeDetail>)
+                      .detail;
+                    onChatHistoryChange({
+                      detail: {
+                        testCaseId: testCase.id,
+                        enabled,
+                        value,
+                      },
+                    } as CustomEvent<ChatHistoryRowChangeDetail>);
+                  }}
+                />
+              </div>
+            </div>
             <ExpectedOutcomeRenderer
               testCaseId={testCase.id}
               fields={testCase.expectedOutcome || []}


### PR DESCRIPTION
## Summary

**4 of 7** in the "D - LLM Test Runner" Figma redesign stack (stacked on #74).

- Question/prompt input becomes a pill-style field with a clear button and an info tooltip explaining what it's used for.
- Chat history moves from an inline panel into a modal, opened via an icon button next to the question input.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx stencil test --spec --passWithNoTests` — 227/227 passing
- [x] `npx eslint` — clean