### PR TITLE
[7/7] feat(validation): gate Run/Run All on the mandatory primary field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ UserInterfaceState.xcuserstate
 generated/
 
 CLAUDE.md
+.claude/

--- a/src/components/llm-test-runner/header/llm-test-runner-header.tsx
+++ b/src/components/llm-test-runner/header/llm-test-runner-header.tsx
@@ -15,6 +15,7 @@ export interface LLMTestRunnerHeaderProps {
   isExportingTestSuite: boolean;
   isExportingTestResults: boolean;
   isRunningAll: boolean;
+  canRunAny: boolean;
   useSave?: boolean;
   isSaving?: boolean;
   usePromptEditor?: boolean;
@@ -34,6 +35,7 @@ export const LLMTestRunnerHeader: FunctionalComponent<
   isExportingTestSuite,
   isExportingTestResults,
   isRunningAll,
+  canRunAny,
   useSave = false,
   isSaving = false,
   usePromptEditor = false,
@@ -143,7 +145,7 @@ export const LLMTestRunnerHeader: FunctionalComponent<
           variant="primary"
           size="md"
           onClick={onRunAll}
-          disabled={isRunningAll}
+          disabled={isRunningAll || !canRunAny}
           loading={isRunningAll}
           icon={isRunningAll ? <SpinnerIcon /> : <PlayIcon />}
         >

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -36,6 +36,7 @@ import {
   resolveDynamicExpectedOutcomes,
 } from '../../lib/test-cases/dynamic-expected-outcome-resolver';
 import * as TestCaseMutations from '../../lib/test-cases/test-case-mutations';
+import { isTestCaseRunnable } from '../../lib/test-cases/test-case-validation';
 import { EvaluationService } from '../../lib/evaluation/evaluation-service';
 import { validateTestCaseInputArray } from '../../schemas/test-case';
 import {
@@ -363,7 +364,10 @@ export class LLMTestRunner {
     this.isRunningAll = true;
     const tasks = [];
     for (const testCase of this.testCases) {
-      if (!testCase.isRunning && testCase.question.trim()) {
+      if (
+        !testCase.isRunning &&
+        isTestCaseRunnable(testCase)
+      ) {
         tasks.push(() =>
           this.runSingleTest(testCase).catch(err => {
             console.error(`⚠️ Test case ${testCase.id} failed`, err);
@@ -470,6 +474,9 @@ export class LLMTestRunner {
           isExportingTestSuite={this.isExportingTestSuite}
           isExportingTestResults={this.isExportingTestResults}
           isRunningAll={this.isRunningAll}
+          canRunAny={this.testCases.some(tc =>
+            isTestCaseRunnable(tc),
+          )}
           useSave={this.useSave}
           isSaving={this.isSaving}
           usePromptEditor={this.usePromptEditor}

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.spec.tsx
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.spec.tsx
@@ -25,7 +25,7 @@ describe('computeTestStatus', () => {
 
   it('returns "not-run" when there is no evaluation result', () => {
     const status = computeTestStatus(makeTestCase({}));
-    expect(status).toEqual({ kind: 'not-run', label: 'Not run' });
+    expect(status).toEqual({ kind: 'not-run', label: 'Not tested' });
   });
 
   it('returns "passed" for a single-field result that passed', () => {

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.tsx
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.tsx
@@ -16,6 +16,7 @@ import {
   ExpectedOutcomeRenderer,
 } from './expected-outcome-renderer';
 import type { ChatHistoryChangeDetail } from './chat-history';
+import { isTestCaseRunnable } from '../../../lib/test-cases/test-case-validation';
 
 export type ChatHistoryRowChangeDetail = {
   testCaseId: string;
@@ -44,7 +45,7 @@ interface TestStatus {
 }
 
 const STATUS_LABEL: Record<StatusKind, string> = {
-  'not-run': 'Not run',
+  'not-run': 'Not tested',
   running: 'Running',
   passed: 'Passed',
   failed: 'Failed',
@@ -95,7 +96,7 @@ export const LLMTestCaseRow: FunctionalComponent<LLMTestCaseRowProps> = ({
   onExpectedOutcomeChange,
   onChatHistoryChange,
 }) => {
-  const canRun = !!testCase.question.trim();
+  const canRun = isTestCaseRunnable(testCase);
   const isRunning = testCase.isRunning;
   const status = computeTestStatus(testCase);
   const questionPreview = testCase.question.trim() || 'New test — click to add a question.';
@@ -129,7 +130,7 @@ export const LLMTestCaseRow: FunctionalComponent<LLMTestCaseRowProps> = ({
             disabled={isRunning || !canRun}
             loading={isRunning}
             icon={isRunning ? <SpinnerIcon /> : <PlayIcon />}
-            aria-label={canRun ? 'Run this test' : 'Enter a question first'}
+            aria-label={canRun ? 'Run this test' : 'Fill in the question and expected output first'}
           >
             {isRunning ? 'Running' : 'Run'}
           </Button>


### PR DESCRIPTION
## Summary

**7 of 7 (final)** in the "D - LLM Test Runner" Figma redesign stack (stacked on #77).

- Wire `isTestCaseRunnable` (added in #73) into the per-row Run button and the header's Run All button (via a new `canRunAny` prop), so Run is disabled until the primary expected-outcome field has a value, matching the Figma proto's mandatory-field state.
- Rename the "Not run" status label to "Not tested".
- Ignore `.claude/` (per-developer Claude Code session state), the same way `CLAUDE.md` itself is already ignored — folded in here since it's a trivial, unrelated one-liner not worth its own PR.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx stencil test --spec --passWithNoTests` — 227/227 passing
- [x] `npx eslint` — clean