### PR TITLE
[8/9] feat(ui): add test-cases toolbar (count, actions, filters, search) per Figma

### DIFF
--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -47,6 +47,7 @@ import {
 import { LLMTestRunnerHeader } from './header/llm-test-runner-header';
 import { LLMTestRunnerSummary } from './summary/llm-test-runner-summary';
 import { LLMTestCases } from './test-cases/llm-test-cases';
+import { TestCasesToolbar } from './test-cases/test-cases-toolbar';
 import { ExpectedOutcomeChangeDetail } from './test-cases/expected-outcome-renderer';
 import type { ChatHistoryRowChangeDetail } from './test-cases/llm-test-case-row';
 
@@ -65,6 +66,7 @@ function nextFrame(): Promise<void> {
     'header/llm-test-runner-header.css',
     'summary/llm-test-runner-summary.css',
     'test-cases/llm-test-cases.css',
+    'test-cases/test-cases-toolbar.css',
     'test-cases/llm-test-case-row.css',
     'test-cases/expected-outcome-renderer.css',
     'test-cases/actions/row-actions.css',
@@ -494,6 +496,13 @@ export class LLMTestRunner {
         )}
         <ErrorMessage message={this.error} onClear={() => (this.error = '')} />
         <div class="test-runner-container__content">
+          <TestCasesToolbar
+            totalCount={this.testCases.length}
+            isExportingTestSuite={this.isExportingTestSuite}
+            onAddTestCase={() => this.addNewTestCase()}
+            onImport={file => this.handleImport(file)}
+            onExportSuite={() => this.handleExportTestSuite()}
+          />
           <LLMTestCases
             testCases={this.testCases}
             dynamicResolutionSupported={!!this.resolveExpectedOutcome}

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -45,9 +45,17 @@ import {
   validateExpectedOutcomeSchema,
 } from '../../schemas/expected-outcome';
 import { LLMTestRunnerHeader } from './header/llm-test-runner-header';
-import { LLMTestRunnerSummary } from './summary/llm-test-runner-summary';
+import {
+  LLMTestRunnerSummary,
+  computeSummaryStats,
+} from './summary/llm-test-runner-summary';
 import { LLMTestCases } from './test-cases/llm-test-cases';
 import { TestCasesToolbar } from './test-cases/test-cases-toolbar';
+import {
+  filterTestCasesByStatus,
+  filterTestCasesByQuery,
+  type StatusFilter,
+} from './test-cases/test-case-filtering';
 import { ExpectedOutcomeChangeDetail } from './test-cases/expected-outcome-renderer';
 import type { ChatHistoryRowChangeDetail } from './test-cases/llm-test-case-row';
 
@@ -112,6 +120,9 @@ export class LLMTestRunner {
   @State() isExportingTestResults: boolean = false;
   @State() isSaving: boolean = false;
   @State() showSummary: boolean = true;
+  @State() activeFilter: StatusFilter = 'all';
+  @State() searchQuery: string = '';
+  @State() isSearchExpanded: boolean = false;
 
   private evaluationService: EvaluationService;
 
@@ -470,6 +481,7 @@ export class LLMTestRunner {
   }
 
   render() {
+    const stats = computeSummaryStats(this.testCases);
     return (
       <div class="test-runner-container">
         <LLMTestRunnerHeader
@@ -498,13 +510,25 @@ export class LLMTestRunner {
         <div class="test-runner-container__content">
           <TestCasesToolbar
             totalCount={this.testCases.length}
+            notTestedCount={stats.notRun}
+            failedCount={stats.failed}
+            passedCount={stats.passed}
+            activeFilter={this.activeFilter}
             isExportingTestSuite={this.isExportingTestSuite}
+            searchQuery={this.searchQuery}
+            isSearchExpanded={this.isSearchExpanded}
             onAddTestCase={() => this.addNewTestCase()}
             onImport={file => this.handleImport(file)}
             onExportSuite={() => this.handleExportTestSuite()}
+            onFilterChange={filter => (this.activeFilter = filter)}
+            onSearchQueryChange={query => (this.searchQuery = query)}
+            onSearchExpandedChange={expanded => (this.isSearchExpanded = expanded)}
           />
           <LLMTestCases
-            testCases={this.testCases}
+            testCases={filterTestCasesByQuery(
+              filterTestCasesByStatus(this.testCases, this.activeFilter),
+              this.searchQuery,
+            )}
             dynamicResolutionSupported={!!this.resolveExpectedOutcome}
             extractorIds={getExtractorIds(this.evaluationSourceExtractors)}
             onRun={testCase => this.runSingleTest(testCase).catch(() => {})}

--- a/src/components/llm-test-runner/test-cases/test-case-filtering.ts
+++ b/src/components/llm-test-runner/test-cases/test-case-filtering.ts
@@ -3,11 +3,8 @@ import { computeTestStatus } from './llm-test-case-row';
 
 export type StatusFilter = 'all' | 'not-tested' | 'failed' | 'passed';
 
-/**
- * Buckets match the ones computeSummaryStats already uses: 'not-tested'
- * covers both 'not-run' and the transient 'running' state, 'failed'
- * covers both 'failed' and 'partial'.
- */
+/** Buckets match computeSummaryStats: 'not-tested' covers 'not-run' + 'running',
+ * 'failed' covers 'failed' + 'partial'. */
 export function filterTestCasesByStatus(
   testCases: TestCase[],
   filter: StatusFilter,
@@ -22,7 +19,6 @@ export function filterTestCasesByStatus(
   });
 }
 
-/** Case-insensitive substring match on the question text. */
 export function filterTestCasesByQuery(
   testCases: TestCase[],
   query: string,

--- a/src/components/llm-test-runner/test-cases/test-case-filtering.ts
+++ b/src/components/llm-test-runner/test-cases/test-case-filtering.ts
@@ -1,0 +1,36 @@
+import { TestCase } from '../../../types/llm-test-runner';
+import { computeTestStatus } from './llm-test-case-row';
+
+export type StatusFilter = 'all' | 'not-tested' | 'failed' | 'passed';
+
+/**
+ * Buckets match the ones computeSummaryStats already uses: 'not-tested'
+ * covers both 'not-run' and the transient 'running' state, 'failed'
+ * covers both 'failed' and 'partial'.
+ */
+export function filterTestCasesByStatus(
+  testCases: TestCase[],
+  filter: StatusFilter,
+): TestCase[] {
+  if (filter === 'all') return testCases;
+
+  return testCases.filter(testCase => {
+    const { kind } = computeTestStatus(testCase);
+    if (filter === 'not-tested') return kind === 'not-run' || kind === 'running';
+    if (filter === 'failed') return kind === 'failed' || kind === 'partial';
+    return kind === 'passed';
+  });
+}
+
+/** Case-insensitive substring match on the question text. */
+export function filterTestCasesByQuery(
+  testCases: TestCase[],
+  query: string,
+): TestCase[] {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return testCases;
+
+  return testCases.filter(testCase =>
+    testCase.question.toLowerCase().includes(trimmed),
+  );
+}

--- a/src/components/llm-test-runner/test-cases/test-cases-toolbar.css
+++ b/src/components/llm-test-runner/test-cases/test-cases-toolbar.css
@@ -1,0 +1,44 @@
+/* ------------------------------------------------------------------ */
+/* Test cases toolbar — question count, add/import/export actions, and */
+/* (in a later PR) quick status filters + search, sitting above the    */
+/* test-case list.                                                     */
+/* ------------------------------------------------------------------ */
+
+.test-cases-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) 0;
+}
+
+.test-cases-toolbar__left {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+}
+
+.test-cases-toolbar__count {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--muted-foreground);
+  white-space: nowrap;
+}
+
+.test-cases-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding-left: var(--spacing-4);
+  border-left: var(--border-width) solid var(--border-strong);
+}
+
+.test-cases-toolbar__file-input {
+  display: none;
+}
+
+/* The shared IconButton's --secondary variant has no border; the
+ * toolbar's action buttons need one to match the Figma spec. */
+.test-cases-toolbar__icon-btn.ui-icon-button--secondary {
+  border-color: var(--border);
+}

--- a/src/components/llm-test-runner/test-cases/test-cases-toolbar.css
+++ b/src/components/llm-test-runner/test-cases/test-cases-toolbar.css
@@ -1,21 +1,26 @@
 /* ------------------------------------------------------------------ */
-/* Test cases toolbar — question count, add/import/export actions, and */
-/* (in a later PR) quick status filters + search, sitting above the    */
-/* test-case list.                                                     */
+/* Test cases toolbar — question count, add/import/export actions,     */
+/* quick status filters, and search, sitting above the test-case list. */
 /* ------------------------------------------------------------------ */
 
+/* Shares .test-cases's background + horizontal padding so the two sit
+ * on one continuous tray with no seam, and the toolbar's content lines
+ * up with the cards below it. */
 .test-cases-toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-2);
-  padding: var(--spacing-2) 0;
+  padding: var(--spacing-3) var(--spacing-5) var(--spacing-2);
+  background: var(--muted);
 }
 
 .test-cases-toolbar__left {
   display: flex;
   align-items: center;
   gap: var(--spacing-4);
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
 .test-cases-toolbar__count {
@@ -37,8 +42,74 @@
   display: none;
 }
 
-/* The shared IconButton's --secondary variant has no border; the
- * toolbar's action buttons need one to match the Figma spec. */
-.test-cases-toolbar__icon-btn.ui-icon-button--secondary {
-  border-color: var(--border);
+.test-cases-toolbar__filters {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  height: 32px;
+  padding-left: var(--spacing-4);
+  border-left: var(--border-width) solid var(--border-strong);
+}
+
+/* Inactive pills use --background (white), not --secondary — --secondary
+ * resolves to the same value as this toolbar's --muted background in
+ * this token set, which would make an inactive pill invisible. */
+.test-cases-toolbar__filter-pill {
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  padding: 5px 17px;
+  border-radius: var(--radius-full);
+  border: var(--border-width) solid var(--border-strong);
+  background: var(--background);
+  color: var(--muted-foreground);
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.test-cases-toolbar__filter-pill:hover:not(.test-cases-toolbar__filter-pill--active) {
+  border-color: var(--ring);
+  color: var(--foreground);
+}
+
+.test-cases-toolbar__filter-pill:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.test-cases-toolbar__filter-pill--active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.test-cases-toolbar__search {
+  flex-shrink: 0;
+}
+
+.test-cases-toolbar__search-input {
+  width: 220px;
+  height: 32px;
+  box-sizing: border-box;
+  padding: 0 var(--spacing-3);
+  border: var(--border-width) solid var(--input);
+  border-radius: var(--radius-full);
+  background: var(--background);
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  color: var(--foreground);
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.test-cases-toolbar__search-input:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 4px var(--ring-soft);
 }

--- a/src/components/llm-test-runner/test-cases/test-cases-toolbar.css
+++ b/src/components/llm-test-runner/test-cases/test-cases-toolbar.css
@@ -1,11 +1,5 @@
-/* ------------------------------------------------------------------ */
-/* Test cases toolbar — question count, add/import/export actions,     */
-/* quick status filters, and search, sitting above the test-case list. */
-/* ------------------------------------------------------------------ */
-
-/* Shares .test-cases's background + horizontal padding so the two sit
- * on one continuous tray with no seam, and the toolbar's content lines
- * up with the cards below it. */
+/* Shares .test-cases's background + horizontal padding so the two sit on one
+ * continuous tray with no seam. */
 .test-cases-toolbar {
   display: flex;
   align-items: center;
@@ -51,9 +45,8 @@
   border-left: var(--border-width) solid var(--border-strong);
 }
 
-/* Inactive pills use --background (white), not --secondary — --secondary
- * resolves to the same value as this toolbar's --muted background in
- * this token set, which would make an inactive pill invisible. */
+/* --secondary resolves to this toolbar's --muted background in this token
+ * set, which would make an inactive pill invisible — use --background instead. */
 .test-cases-toolbar__filter-pill {
   display: inline-flex;
   align-items: center;

--- a/src/components/llm-test-runner/test-cases/test-cases-toolbar.tsx
+++ b/src/components/llm-test-runner/test-cases/test-cases-toolbar.tsx
@@ -1,0 +1,80 @@
+import { h, FunctionalComponent } from '@stencil/core';
+import { IconButton } from '../../../lib/ui/icon-button/index';
+import { PlusIcon, UploadIcon, DownloadIcon } from '../../../lib/ui/icons/icons';
+
+export interface TestCasesToolbarProps {
+  totalCount: number;
+  isExportingTestSuite: boolean;
+  onAddTestCase: () => void;
+  onImport: (file: File) => void;
+  onExportSuite: () => void;
+}
+
+export const TestCasesToolbar: FunctionalComponent<TestCasesToolbarProps> = ({
+  totalCount,
+  isExportingTestSuite,
+  onAddTestCase,
+  onImport,
+  onExportSuite,
+}) => {
+  let fileInputRef: HTMLInputElement;
+
+  const handleFileSelect = () => {
+    fileInputRef?.click();
+  };
+
+  const handleFileChange = (event: Event) => {
+    const target = event.target as HTMLInputElement;
+    const file = target.files?.[0];
+    target.value = ''; // Clear for re-upload
+    if (file) {
+      onImport(file);
+    }
+  };
+
+  const noun = totalCount === 1 ? 'Question' : 'Questions';
+
+  return (
+    <div class="test-cases-toolbar">
+      <div class="test-cases-toolbar__left">
+        <span class="test-cases-toolbar__count">
+          {totalCount} {noun}
+        </span>
+        <div class="test-cases-toolbar__actions">
+          <input
+            class="test-cases-toolbar__file-input"
+            type="file"
+            ref={el => (fileInputRef = el as HTMLInputElement)}
+            onChange={handleFileChange}
+            accept=".json,application/json"
+          />
+          <IconButton
+            variant="secondary"
+            class="test-cases-toolbar__icon-btn"
+            onClick={onAddTestCase}
+            title="Add question"
+          >
+            <PlusIcon />
+          </IconButton>
+          <IconButton
+            variant="secondary"
+            class="test-cases-toolbar__icon-btn"
+            onClick={handleFileSelect}
+            title="Import test suite"
+          >
+            <UploadIcon />
+          </IconButton>
+          <IconButton
+            variant="secondary"
+            class="test-cases-toolbar__icon-btn"
+            onClick={onExportSuite}
+            loading={isExportingTestSuite}
+            title="Export test suite"
+          >
+            <DownloadIcon />
+          </IconButton>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/llm-test-runner/test-cases/test-cases-toolbar.tsx
+++ b/src/components/llm-test-runner/test-cases/test-cases-toolbar.tsx
@@ -1,22 +1,66 @@
 import { h, FunctionalComponent } from '@stencil/core';
 import { IconButton } from '../../../lib/ui/icon-button/index';
-import { PlusIcon, UploadIcon, DownloadIcon } from '../../../lib/ui/icons/icons';
+import {
+  PlusIcon,
+  UploadIcon,
+  DownloadIcon,
+  SearchIcon,
+} from '../../../lib/ui/icons/icons';
+import type { StatusFilter } from './test-case-filtering';
 
 export interface TestCasesToolbarProps {
   totalCount: number;
+  notTestedCount: number;
+  failedCount: number;
+  passedCount: number;
+  activeFilter: StatusFilter;
   isExportingTestSuite: boolean;
+  searchQuery: string;
+  isSearchExpanded: boolean;
   onAddTestCase: () => void;
   onImport: (file: File) => void;
   onExportSuite: () => void;
+  onFilterChange: (filter: StatusFilter) => void;
+  onSearchQueryChange: (query: string) => void;
+  onSearchExpandedChange: (expanded: boolean) => void;
 }
+
+const FILTERS: { value: StatusFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'not-tested', label: 'Not Tested' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'passed', label: 'Passed' },
+];
 
 export const TestCasesToolbar: FunctionalComponent<TestCasesToolbarProps> = ({
   totalCount,
+  notTestedCount,
+  failedCount,
+  passedCount,
+  activeFilter,
   isExportingTestSuite,
+  searchQuery,
+  isSearchExpanded,
   onAddTestCase,
   onImport,
   onExportSuite,
+  onFilterChange,
+  onSearchQueryChange,
+  onSearchExpandedChange,
 }) => {
+  const countFor = (filter: StatusFilter): number | null => {
+    switch (filter) {
+      case 'all':
+        return null;
+      case 'not-tested':
+        return notTestedCount;
+      case 'failed':
+        return failedCount;
+      case 'passed':
+        return passedCount;
+    }
+  };
+
   let fileInputRef: HTMLInputElement;
 
   const handleFileSelect = () => {
@@ -49,7 +93,7 @@ export const TestCasesToolbar: FunctionalComponent<TestCasesToolbarProps> = ({
             accept=".json,application/json"
           />
           <IconButton
-            variant="secondary"
+            variant="outline"
             class="test-cases-toolbar__icon-btn"
             onClick={onAddTestCase}
             title="Add question"
@@ -57,7 +101,7 @@ export const TestCasesToolbar: FunctionalComponent<TestCasesToolbarProps> = ({
             <PlusIcon />
           </IconButton>
           <IconButton
-            variant="secondary"
+            variant="outline"
             class="test-cases-toolbar__icon-btn"
             onClick={handleFileSelect}
             title="Import test suite"
@@ -65,7 +109,7 @@ export const TestCasesToolbar: FunctionalComponent<TestCasesToolbarProps> = ({
             <UploadIcon />
           </IconButton>
           <IconButton
-            variant="secondary"
+            variant="outline"
             class="test-cases-toolbar__icon-btn"
             onClick={onExportSuite}
             loading={isExportingTestSuite}
@@ -74,6 +118,59 @@ export const TestCasesToolbar: FunctionalComponent<TestCasesToolbarProps> = ({
             <DownloadIcon />
           </IconButton>
         </div>
+        <div class="test-cases-toolbar__filters">
+          {FILTERS.map(filter => {
+            const count = countFor(filter.value);
+            const isActive = activeFilter === filter.value;
+            return (
+              <button
+                type="button"
+                class={{
+                  'test-cases-toolbar__filter-pill': true,
+                  'test-cases-toolbar__filter-pill--active': isActive,
+                }}
+                aria-pressed={isActive}
+                onClick={() => onFilterChange(filter.value)}
+                key={filter.value}
+              >
+                {filter.label}
+                {count !== null ? ` ${count}` : ''}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div class="test-cases-toolbar__search">
+        {isSearchExpanded ? (
+          <input
+            type="text"
+            class="test-cases-toolbar__search-input"
+            placeholder="Search questions…"
+            value={searchQuery}
+            ref={el => el?.focus()}
+            onInput={e =>
+              onSearchQueryChange((e.target as HTMLInputElement).value)
+            }
+            onBlur={e => {
+              // Read the live DOM value rather than the searchQuery prop —
+              // Stencil's re-render after onInput is async, so a fast
+              // clear-then-blur can fire before this closure's prop
+              // updates, which would otherwise leave the input stuck open.
+              if (!(e.target as HTMLInputElement).value.trim()) {
+                onSearchExpandedChange(false);
+              }
+            }}
+          />
+        ) : (
+          <IconButton
+            variant="outline"
+            class="test-cases-toolbar__icon-btn"
+            onClick={() => onSearchExpandedChange(true)}
+            title="Search questions"
+          >
+            <SearchIcon />
+          </IconButton>
+        )}
       </div>
     </div>
   );

--- a/src/components/llm-test-runner/test-cases/test-cases-toolbar.tsx
+++ b/src/components/llm-test-runner/test-cases/test-cases-toolbar.tsx
@@ -152,10 +152,8 @@ export const TestCasesToolbar: FunctionalComponent<TestCasesToolbarProps> = ({
               onSearchQueryChange((e.target as HTMLInputElement).value)
             }
             onBlur={e => {
-              // Read the live DOM value rather than the searchQuery prop —
-              // Stencil's re-render after onInput is async, so a fast
-              // clear-then-blur can fire before this closure's prop
-              // updates, which would otherwise leave the input stuck open.
+              // Read the live DOM value, not the searchQuery prop — Stencil's async
+              // re-render can lag a fast clear-then-blur, leaving the input stuck open.
               if (!(e.target as HTMLInputElement).value.trim()) {
                 onSearchExpandedChange(false);
               }

--- a/src/lib/ui/icons/icons.tsx
+++ b/src/lib/ui/icons/icons.tsx
@@ -182,7 +182,6 @@ export const ArrowRightIcon: FunctionalComponent<IconProps> = ({
   </svg>
 );
 
-/** Magnifying glass — used to search the test-case list. */
 export const SearchIcon: FunctionalComponent<IconProps> = ({ class: cls }) => (
   <svg {...baseProps} class={cls}>
     <circle cx="11" cy="11" r="8" />

--- a/src/lib/ui/icons/icons.tsx
+++ b/src/lib/ui/icons/icons.tsx
@@ -181,3 +181,11 @@ export const ArrowRightIcon: FunctionalComponent<IconProps> = ({
     <polyline points="12 5 19 12 12 19" />
   </svg>
 );
+
+/** Magnifying glass — used to search the test-case list. */
+export const SearchIcon: FunctionalComponent<IconProps> = ({ class: cls }) => (
+  <svg {...baseProps} class={cls}>
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);


### PR DESCRIPTION
## Summary

Final PR for the topbar redesign (Figma node [208-51984](https://www.figma.com/proto/xs1mSrIeUFvun9BZ4r8Y8m/D---LLM-Test-Runner?node-id=208-51984&m=dev&scaling=min-zoom&content-scaling=fixed&page-id=193%3A44999)), stacked on #78. Originally planned as 3 separate PRs (shell, filters, search) but combined into one at the user's request since the total change is still small.

Adds `TestCasesToolbar` above the test-case list:
- Live question count and Add/Import/Export-suite icon buttons, wired to the existing `addNewTestCase`/`handleImport`/`handleExportTestSuite` handlers already on `LLMTestRunner`.
- Quick-filter pills (All/Not Tested/Failed/Passed) with live counts, reusing the same status bucketing `computeSummaryStats` already uses for the Summary panel.
- Search: the search icon expands into a focused input that filters the list live by question text, collapsing back to the icon on blur when empty.
- New `test-case-filtering.ts` (`filterTestCasesByStatus`, `filterTestCasesByQuery`), composed together in `LLMTestRunner`'s `render()` before the list is passed to `LLMTestCases`. The toolbar itself always receives the **unfiltered** `testCases` so the count and pill totals reflect the suite, not the current view.

**Out of scope** (per team discussion, see the earlier design-feedback thread): the model-selector dropdown, "Create report", and the suite title/avatar/date/share row are all host-app chrome, not part of this library. "Run all" and the existing header (Import suite/Export suite/Add question/Save) are untouched.

## Fixes made after initial local testing
- Toolbar background now matches `.test-cases`'s `--muted` background and horizontal padding, so there's no white seam and the question count lines up with the card content below it.
- Icon buttons switched from the `secondary` variant to `outline` — `--secondary` resolves to the same value as `--muted` in this token set, which made the buttons nearly invisible against the tray.
- Fixed a stale-closure bug in the search collapse-on-blur: it now reads the input's live DOM value instead of the `searchQuery` prop, since Stencil's re-render after `onInput` is async and a fast clear-then-blur could otherwise leave the input stuck open.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx stencil test --spec --passWithNoTests` — 227/227 passing
- [x] `npx eslint` — clean
- [x] Verified live in the browser: toolbar/list background and alignment match Figma, question count updates live, Add question works end-to-end, filter pills toggle and filter the list correctly with live counts, search expands/filters/collapses correctly