### PR TITLE
[Bridge] feat(ui): add test-cases toolbar (count, actions, filters, search) per Figma (was #79)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ UserInterfaceState.xcuserstate
 generated/
 
 CLAUDE.md
+.claude/

--- a/src/components/llm-test-runner/header/llm-test-runner-header.tsx
+++ b/src/components/llm-test-runner/header/llm-test-runner-header.tsx
@@ -15,6 +15,7 @@ export interface LLMTestRunnerHeaderProps {
   isExportingTestSuite: boolean;
   isExportingTestResults: boolean;
   isRunningAll: boolean;
+  canRunAny: boolean;
   useSave?: boolean;
   isSaving?: boolean;
   usePromptEditor?: boolean;
@@ -34,6 +35,7 @@ export const LLMTestRunnerHeader: FunctionalComponent<
   isExportingTestSuite,
   isExportingTestResults,
   isRunningAll,
+  canRunAny,
   useSave = false,
   isSaving = false,
   usePromptEditor = false,
@@ -143,7 +145,7 @@ export const LLMTestRunnerHeader: FunctionalComponent<
           variant="primary"
           size="md"
           onClick={onRunAll}
-          disabled={isRunningAll}
+          disabled={isRunningAll || !canRunAny}
           loading={isRunningAll}
           icon={isRunningAll ? <SpinnerIcon /> : <PlayIcon />}
         >

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -36,6 +36,7 @@ import {
   resolveDynamicExpectedOutcomes,
 } from '../../lib/test-cases/dynamic-expected-outcome-resolver';
 import * as TestCaseMutations from '../../lib/test-cases/test-case-mutations';
+import { isTestCaseRunnable } from '../../lib/test-cases/test-case-validation';
 import { EvaluationService } from '../../lib/evaluation/evaluation-service';
 import { validateTestCaseInputArray } from '../../schemas/test-case';
 import {
@@ -363,7 +364,10 @@ export class LLMTestRunner {
     this.isRunningAll = true;
     const tasks = [];
     for (const testCase of this.testCases) {
-      if (!testCase.isRunning && testCase.question.trim()) {
+      if (
+        !testCase.isRunning &&
+        isTestCaseRunnable(testCase)
+      ) {
         tasks.push(() =>
           this.runSingleTest(testCase).catch(err => {
             console.error(`⚠️ Test case ${testCase.id} failed`, err);
@@ -470,6 +474,9 @@ export class LLMTestRunner {
           isExportingTestSuite={this.isExportingTestSuite}
           isExportingTestResults={this.isExportingTestResults}
           isRunningAll={this.isRunningAll}
+          canRunAny={this.testCases.some(tc =>
+            isTestCaseRunnable(tc),
+          )}
           useSave={this.useSave}
           isSaving={this.isSaving}
           usePromptEditor={this.usePromptEditor}

--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -45,8 +45,17 @@ import {
   validateExpectedOutcomeSchema,
 } from '../../schemas/expected-outcome';
 import { LLMTestRunnerHeader } from './header/llm-test-runner-header';
-import { LLMTestRunnerSummary } from './summary/llm-test-runner-summary';
+import {
+  LLMTestRunnerSummary,
+  computeSummaryStats,
+} from './summary/llm-test-runner-summary';
 import { LLMTestCases } from './test-cases/llm-test-cases';
+import { TestCasesToolbar } from './test-cases/test-cases-toolbar';
+import {
+  filterTestCasesByStatus,
+  filterTestCasesByQuery,
+  type StatusFilter,
+} from './test-cases/test-case-filtering';
 import { ExpectedOutcomeChangeDetail } from './test-cases/expected-outcome-renderer';
 import type { ChatHistoryRowChangeDetail } from './test-cases/llm-test-case-row';
 
@@ -65,6 +74,7 @@ function nextFrame(): Promise<void> {
     'header/llm-test-runner-header.css',
     'summary/llm-test-runner-summary.css',
     'test-cases/llm-test-cases.css',
+    'test-cases/test-cases-toolbar.css',
     'test-cases/llm-test-case-row.css',
     'test-cases/expected-outcome-renderer.css',
     'test-cases/actions/row-actions.css',
@@ -110,6 +120,9 @@ export class LLMTestRunner {
   @State() isExportingTestResults: boolean = false;
   @State() isSaving: boolean = false;
   @State() showSummary: boolean = true;
+  @State() activeFilter: StatusFilter = 'all';
+  @State() searchQuery: string = '';
+  @State() isSearchExpanded: boolean = false;
 
   private evaluationService: EvaluationService;
 
@@ -468,6 +481,7 @@ export class LLMTestRunner {
   }
 
   render() {
+    const stats = computeSummaryStats(this.testCases);
     return (
       <div class="test-runner-container">
         <LLMTestRunnerHeader
@@ -494,8 +508,27 @@ export class LLMTestRunner {
         )}
         <ErrorMessage message={this.error} onClear={() => (this.error = '')} />
         <div class="test-runner-container__content">
+          <TestCasesToolbar
+            totalCount={this.testCases.length}
+            notTestedCount={stats.notRun}
+            failedCount={stats.failed}
+            passedCount={stats.passed}
+            activeFilter={this.activeFilter}
+            isExportingTestSuite={this.isExportingTestSuite}
+            searchQuery={this.searchQuery}
+            isSearchExpanded={this.isSearchExpanded}
+            onAddTestCase={() => this.addNewTestCase()}
+            onImport={file => this.handleImport(file)}
+            onExportSuite={() => this.handleExportTestSuite()}
+            onFilterChange={filter => (this.activeFilter = filter)}
+            onSearchQueryChange={query => (this.searchQuery = query)}
+            onSearchExpandedChange={expanded => (this.isSearchExpanded = expanded)}
+          />
           <LLMTestCases
-            testCases={this.testCases}
+            testCases={filterTestCasesByQuery(
+              filterTestCasesByStatus(this.testCases, this.activeFilter),
+              this.searchQuery,
+            )}
             dynamicResolutionSupported={!!this.resolveExpectedOutcome}
             extractorIds={getExtractorIds(this.evaluationSourceExtractors)}
             onRun={testCase => this.runSingleTest(testCase).catch(() => {})}

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.spec.tsx
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.spec.tsx
@@ -25,7 +25,7 @@ describe('computeTestStatus', () => {
 
   it('returns "not-run" when there is no evaluation result', () => {
     const status = computeTestStatus(makeTestCase({}));
-    expect(status).toEqual({ kind: 'not-run', label: 'Not run' });
+    expect(status).toEqual({ kind: 'not-run', label: 'Not tested' });
   });
 
   it('returns "passed" for a single-field result that passed', () => {

--- a/src/components/llm-test-runner/test-cases/llm-test-case-row.tsx
+++ b/src/components/llm-test-runner/test-cases/llm-test-case-row.tsx
@@ -16,6 +16,7 @@ import {
   ExpectedOutcomeRenderer,
 } from './expected-outcome-renderer';
 import type { ChatHistoryChangeDetail } from './chat-history';
+import { isTestCaseRunnable } from '../../../lib/test-cases/test-case-validation';
 
 export type ChatHistoryRowChangeDetail = {
   testCaseId: string;
@@ -44,7 +45,7 @@ interface TestStatus {
 }
 
 const STATUS_LABEL: Record<StatusKind, string> = {
-  'not-run': 'Not run',
+  'not-run': 'Not tested',
   running: 'Running',
   passed: 'Passed',
   failed: 'Failed',
@@ -95,7 +96,7 @@ export const LLMTestCaseRow: FunctionalComponent<LLMTestCaseRowProps> = ({
   onExpectedOutcomeChange,
   onChatHistoryChange,
 }) => {
-  const canRun = !!testCase.question.trim();
+  const canRun = isTestCaseRunnable(testCase);
   const isRunning = testCase.isRunning;
   const status = computeTestStatus(testCase);
   const questionPreview = testCase.question.trim() || 'New test — click to add a question.';
@@ -129,7 +130,7 @@ export const LLMTestCaseRow: FunctionalComponent<LLMTestCaseRowProps> = ({
             disabled={isRunning || !canRun}
             loading={isRunning}
             icon={isRunning ? <SpinnerIcon /> : <PlayIcon />}
-            aria-label={canRun ? 'Run this test' : 'Enter a question first'}
+            aria-label={canRun ? 'Run this test' : 'Fill in the question and expected output first'}
           >
             {isRunning ? 'Running' : 'Run'}
           </Button>

--- a/src/components/llm-test-runner/test-cases/test-case-filtering.ts
+++ b/src/components/llm-test-runner/test-cases/test-case-filtering.ts
@@ -1,0 +1,32 @@
+import { TestCase } from '../../../types/llm-test-runner';
+import { computeTestStatus } from './llm-test-case-row';
+
+export type StatusFilter = 'all' | 'not-tested' | 'failed' | 'passed';
+
+/** Buckets match computeSummaryStats: 'not-tested' covers 'not-run' + 'running',
+ * 'failed' covers 'failed' + 'partial'. */
+export function filterTestCasesByStatus(
+  testCases: TestCase[],
+  filter: StatusFilter,
+): TestCase[] {
+  if (filter === 'all') return testCases;
+
+  return testCases.filter(testCase => {
+    const { kind } = computeTestStatus(testCase);
+    if (filter === 'not-tested') return kind === 'not-run' || kind === 'running';
+    if (filter === 'failed') return kind === 'failed' || kind === 'partial';
+    return kind === 'passed';
+  });
+}
+
+export function filterTestCasesByQuery(
+  testCases: TestCase[],
+  query: string,
+): TestCase[] {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return testCases;
+
+  return testCases.filter(testCase =>
+    testCase.question.toLowerCase().includes(trimmed),
+  );
+}

--- a/src/components/llm-test-runner/test-cases/test-cases-toolbar.css
+++ b/src/components/llm-test-runner/test-cases/test-cases-toolbar.css
@@ -1,0 +1,108 @@
+/* Shares .test-cases's background + horizontal padding so the two sit on one
+ * continuous tray with no seam. */
+.test-cases-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3) var(--spacing-5) var(--spacing-2);
+  background: var(--muted);
+}
+
+.test-cases-toolbar__left {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.test-cases-toolbar__count {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--muted-foreground);
+  white-space: nowrap;
+}
+
+.test-cases-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding-left: var(--spacing-4);
+  border-left: var(--border-width) solid var(--border-strong);
+}
+
+.test-cases-toolbar__file-input {
+  display: none;
+}
+
+.test-cases-toolbar__filters {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  height: 32px;
+  padding-left: var(--spacing-4);
+  border-left: var(--border-width) solid var(--border-strong);
+}
+
+/* --secondary resolves to this toolbar's --muted background in this token
+ * set, which would make an inactive pill invisible — use --background instead. */
+.test-cases-toolbar__filter-pill {
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  padding: 5px 17px;
+  border-radius: var(--radius-full);
+  border: var(--border-width) solid var(--border-strong);
+  background: var(--background);
+  color: var(--muted-foreground);
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.test-cases-toolbar__filter-pill:hover:not(.test-cases-toolbar__filter-pill--active) {
+  border-color: var(--ring);
+  color: var(--foreground);
+}
+
+.test-cases-toolbar__filter-pill:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.test-cases-toolbar__filter-pill--active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.test-cases-toolbar__search {
+  flex-shrink: 0;
+}
+
+.test-cases-toolbar__search-input {
+  width: 220px;
+  height: 32px;
+  box-sizing: border-box;
+  padding: 0 var(--spacing-3);
+  border: var(--border-width) solid var(--input);
+  border-radius: var(--radius-full);
+  background: var(--background);
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  color: var(--foreground);
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.test-cases-toolbar__search-input:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 4px var(--ring-soft);
+}

--- a/src/components/llm-test-runner/test-cases/test-cases-toolbar.tsx
+++ b/src/components/llm-test-runner/test-cases/test-cases-toolbar.tsx
@@ -1,0 +1,175 @@
+import { h, FunctionalComponent } from '@stencil/core';
+import { IconButton } from '../../../lib/ui/icon-button/index';
+import {
+  PlusIcon,
+  UploadIcon,
+  DownloadIcon,
+  SearchIcon,
+} from '../../../lib/ui/icons/icons';
+import type { StatusFilter } from './test-case-filtering';
+
+export interface TestCasesToolbarProps {
+  totalCount: number;
+  notTestedCount: number;
+  failedCount: number;
+  passedCount: number;
+  activeFilter: StatusFilter;
+  isExportingTestSuite: boolean;
+  searchQuery: string;
+  isSearchExpanded: boolean;
+  onAddTestCase: () => void;
+  onImport: (file: File) => void;
+  onExportSuite: () => void;
+  onFilterChange: (filter: StatusFilter) => void;
+  onSearchQueryChange: (query: string) => void;
+  onSearchExpandedChange: (expanded: boolean) => void;
+}
+
+const FILTERS: { value: StatusFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'not-tested', label: 'Not Tested' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'passed', label: 'Passed' },
+];
+
+export const TestCasesToolbar: FunctionalComponent<TestCasesToolbarProps> = ({
+  totalCount,
+  notTestedCount,
+  failedCount,
+  passedCount,
+  activeFilter,
+  isExportingTestSuite,
+  searchQuery,
+  isSearchExpanded,
+  onAddTestCase,
+  onImport,
+  onExportSuite,
+  onFilterChange,
+  onSearchQueryChange,
+  onSearchExpandedChange,
+}) => {
+  const countFor = (filter: StatusFilter): number | null => {
+    switch (filter) {
+      case 'all':
+        return null;
+      case 'not-tested':
+        return notTestedCount;
+      case 'failed':
+        return failedCount;
+      case 'passed':
+        return passedCount;
+    }
+  };
+
+  let fileInputRef: HTMLInputElement;
+
+  const handleFileSelect = () => {
+    fileInputRef?.click();
+  };
+
+  const handleFileChange = (event: Event) => {
+    const target = event.target as HTMLInputElement;
+    const file = target.files?.[0];
+    target.value = ''; // Clear for re-upload
+    if (file) {
+      onImport(file);
+    }
+  };
+
+  const noun = totalCount === 1 ? 'Question' : 'Questions';
+
+  return (
+    <div class="test-cases-toolbar">
+      <div class="test-cases-toolbar__left">
+        <span class="test-cases-toolbar__count">
+          {totalCount} {noun}
+        </span>
+        <div class="test-cases-toolbar__actions">
+          <input
+            class="test-cases-toolbar__file-input"
+            type="file"
+            ref={el => (fileInputRef = el as HTMLInputElement)}
+            onChange={handleFileChange}
+            accept=".json,application/json"
+          />
+          <IconButton
+            variant="outline"
+            class="test-cases-toolbar__icon-btn"
+            onClick={onAddTestCase}
+            title="Add question"
+          >
+            <PlusIcon />
+          </IconButton>
+          <IconButton
+            variant="outline"
+            class="test-cases-toolbar__icon-btn"
+            onClick={handleFileSelect}
+            title="Import test suite"
+          >
+            <UploadIcon />
+          </IconButton>
+          <IconButton
+            variant="outline"
+            class="test-cases-toolbar__icon-btn"
+            onClick={onExportSuite}
+            loading={isExportingTestSuite}
+            title="Export test suite"
+          >
+            <DownloadIcon />
+          </IconButton>
+        </div>
+        <div class="test-cases-toolbar__filters">
+          {FILTERS.map(filter => {
+            const count = countFor(filter.value);
+            const isActive = activeFilter === filter.value;
+            return (
+              <button
+                type="button"
+                class={{
+                  'test-cases-toolbar__filter-pill': true,
+                  'test-cases-toolbar__filter-pill--active': isActive,
+                }}
+                aria-pressed={isActive}
+                onClick={() => onFilterChange(filter.value)}
+                key={filter.value}
+              >
+                {filter.label}
+                {count !== null ? ` ${count}` : ''}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div class="test-cases-toolbar__search">
+        {isSearchExpanded ? (
+          <input
+            type="text"
+            class="test-cases-toolbar__search-input"
+            placeholder="Search questions…"
+            value={searchQuery}
+            ref={el => el?.focus()}
+            onInput={e =>
+              onSearchQueryChange((e.target as HTMLInputElement).value)
+            }
+            onBlur={e => {
+              // Read the live DOM value, not the searchQuery prop — Stencil's async
+              // re-render can lag a fast clear-then-blur, leaving the input stuck open.
+              if (!(e.target as HTMLInputElement).value.trim()) {
+                onSearchExpandedChange(false);
+              }
+            }}
+          />
+        ) : (
+          <IconButton
+            variant="outline"
+            class="test-cases-toolbar__icon-btn"
+            onClick={() => onSearchExpandedChange(true)}
+            title="Search questions"
+          >
+            <SearchIcon />
+          </IconButton>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/lib/ui/icons/icons.tsx
+++ b/src/lib/ui/icons/icons.tsx
@@ -181,3 +181,10 @@ export const ArrowRightIcon: FunctionalComponent<IconProps> = ({
     <polyline points="12 5 19 12 12 19" />
   </svg>
 );
+
+export const SearchIcon: FunctionalComponent<IconProps> = ({ class: cls }) => (
+  <svg {...baseProps} class={cls}>
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);


### PR DESCRIPTION
Bridge PR: PR #79 (stack-8 → stack-7) auto-merged after PR #78 (stack-7 → stack-6) had already closed. Same content as #79, already reviewed/approved there.