### PR TITLE
fix(ui): always-opaque toolbar background, darker primary hover

### DIFF
--- a/src/components/llm-test-runner/test-cases/test-cases-toolbar.css
+++ b/src/components/llm-test-runner/test-cases/test-cases-toolbar.css
@@ -1,6 +1,5 @@
-/* No background of its own — sits on whatever the host page provides, same as
- * the rest of the component (see llm-test-runner.css/:host). Sticky via
- * --llmtr-sticky-top since it now holds Run all and the other primary actions. */
+/* Sticky via --llmtr-sticky-top since it holds Run all and the other primary
+ * actions. Opaque so rows scrolling underneath don't show through it. */
 .test-cases-toolbar {
   display: flex;
   align-items: start;
@@ -10,6 +9,10 @@
   position: sticky;
   top: var(--llmtr-sticky-top, 0px);
   z-index: var(--z-sticky);
+  background: var(--background);
+  border-bottom: var(--border-width) solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
 }
 
 .test-cases-toolbar__left {

--- a/src/demo/vanilla-demo.css
+++ b/src/demo/vanilla-demo.css
@@ -147,7 +147,7 @@ h2 {
   /* Bleeds past .container's + body's padding so the background reaches the
    * viewport edge; the matching padding pushes content back in to stay aligned. */
   margin: 0 calc(-1 * (var(--page-padding-x) + 20px));
-  padding: 0 calc(var(--page-padding-x) + 20px);
+  padding: 8px calc(var(--page-padding-x) + 20px) 0;
   /* Fills remaining viewport height; it's the last element, so bleed straight
    * through body's bottom padding too (nothing below to realign against). */
   flex: 1;

--- a/src/lib/ui/button/button.css
+++ b/src/lib/ui/button/button.css
@@ -115,7 +115,7 @@
 }
 
 .ui-button--primary:hover:not(:disabled):not(.ui-button--loading) {
-  opacity: 0.9;
+  background: var(--primary-hover);
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }

--- a/src/lib/ui/icon-button/icon-button.css
+++ b/src/lib/ui/icon-button/icon-button.css
@@ -62,7 +62,7 @@
 }
 
 .ui-icon-button--primary:hover:not(:disabled):not(.ui-icon-button--loading) {
-  opacity: 0.9;
+  background: var(--primary-hover);
   transform: translateY(-1px);
   box-shadow: var(--shadow-sm);
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -122,6 +122,7 @@
   --popover-foreground: #0a0a0a;
 
   --primary: #0e35ff;
+  --primary-hover: #0925b2;
   --primary-foreground: #f9fafb;
 
   --secondary: #f4f4f5;
@@ -182,6 +183,7 @@
   --popover-foreground: #fafafa;
 
   --primary: #3b5bff;
+  --primary-hover: #324dd9;
   --primary-foreground: #f9fafb;
 
   --secondary: #27272a;


### PR DESCRIPTION
## Summary

- **Sticky toolbar bleed-through.** `.test-cases-toolbar` is `position: sticky` but had no background, so test-case rows scrolling underneath showed through it once pinned. Fixed by making the background always opaque (`var(--background)`), with a bottom border, rounded corners (`--radius-lg`, matching the question cards below), and a subtle shadow.
- **Primary button hover.** `.ui-button--primary` / `.ui-icon-button--primary` lightened on hover via `opacity: 0.9`, reading as washed out. They now darken via a new `--primary-hover` token (`#0925b2` light, `#324dd9` dark).
- **Demo spacing.** `#runner-host` in the vanilla demo gets `padding-top: 8px`, matching how the consuming app already wraps the component (`pt: "8px"` in its own layout), so the demo reflects real usage.

## Demo

https://www.loom.com/share/a34716a19ce34061a3e085add72272c2

## Why not track a "stuck" state instead

A prior attempt (#98, closed in favor of this PR) kept the toolbar transparent in normal flow and toggled an opaque background only once pinned, detected via a sentinel element + `IntersectionObserver`/scroll listener. That went through several rounds of genuine correctness bugs — missed crossings on fast/slow scrolls, `overflow-x: hidden` on `body` causing `overflow-y` to compute to `auto` and confusing scroll-root detection, initial-render timing — each fixed but replaced by the next edge case. This PR removes all of that: no JS, no scroll tracking, no sentinel. The toolbar is simply always opaque, which is simpler and can't have the same bug class.

## Test plan

- [x] `npm run lint` — 0 errors (7 pre-existing `no-explicit-any` warnings in untouched files)
- [x] `npx tsc --noEmit -p tsconfig.react.json` — clean
- [x] `npm test` — 229/229 tests pass
- [x] Verified locally against a real consumer app (symlinked), including the `overflow-x: hidden` on `body` case that broke the previous approach
- [ ] Manual: confirm the toolbar's rounded corners and shadow look right against your app's page background

🤖 Generated with [Claude Code](https://claude.com/claude-code)
