### PR TITLE
Fix initialTestCases rejecting its own documented minimal shape

### DIFF
--- a/src/components/llm-test-runner/llm-test-runner.tsx
+++ b/src/components/llm-test-runner/llm-test-runner.tsx
@@ -15,6 +15,7 @@ import { RateLimitedFetcher } from '../../lib/rate-limited-fetcher/rate-limited-
 import {
   ExpectedOutcomeSchema,
   TestCase,
+  TestCaseInput,
   LLMRequestPayload,
   SavePayload,
   ModelResponsePayload,
@@ -90,7 +91,7 @@ export class LLMTestRunner {
   @Prop() usePromptEditor?: boolean = false;
   @Prop() resolveExpectedOutcome?: ExpectedOutcomeResolver;
   @Prop() evaluationSourceExtractors?: EvaluationSourceExtractors;
-  @Prop() initialTestCases?: TestCase[];
+  @Prop() initialTestCases?: TestCaseInput[];
   @Prop() defaultExpectedOutcomeSchema?: ExpectedOutcomeSchema;
   @Prop() llmJudge?: LlmJudge;
   @Prop() readOnly?: boolean = false;

--- a/src/lib/test-cases/test-case-factory.ts
+++ b/src/lib/test-cases/test-case-factory.ts
@@ -120,7 +120,9 @@ export function createExpectedOutcomeFromSchema(
 /**
  * Creates a runtime test case from validated input data.
  * The input is expected to already satisfy `TestCaseInput`,
- * and this function only performs normalization/defaulting.
+ * and this function only performs normalization/defaulting --
+ * including generating an id when the input omits one (the minimal
+ * { question, expectedOutcome } shape the README documents).
  *
  * @param data - Validated test case input
  * @returns A normalized TestCase object with runtime defaults applied
@@ -128,6 +130,7 @@ export function createExpectedOutcomeFromSchema(
 export function createTestCaseFromInput(data: TestCaseInput): TestCase {
   return {
     ...data,
+    id: data.id ?? crypto.randomUUID(),
     chatHistory: data.chatHistory ?? { enabled: false, value: '' },
     expectedOutcome: data.expectedOutcome.map(normalizeExpectedOutcomeField),
   };

--- a/src/schemas/test-case.spec.ts
+++ b/src/schemas/test-case.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from '@jest/globals';
+
+import {
+  validateTestCaseInput,
+  validateTestCaseInputArray,
+} from './test-case';
+
+const minimalCase = {
+  question: 'India, Karnataka',
+  expectedOutcome: [
+    { type: 'text' as const, label: 'Timezone', value: 'Asia/Kolkata' },
+  ],
+};
+
+describe('validateTestCaseInput', () => {
+  it('accepts the minimal { question, expectedOutcome } shape with no id', () => {
+    expect(() => validateTestCaseInput(minimalCase)).not.toThrow();
+  });
+
+  it('accepts an explicit id too', () => {
+    expect(() =>
+      validateTestCaseInput({ ...minimalCase, id: 'abc' }),
+    ).not.toThrow();
+  });
+});
+
+describe('validateTestCaseInputArray', () => {
+  it('accepts an array of minimal test cases with no id', () => {
+    expect(() =>
+      validateTestCaseInputArray([minimalCase, minimalCase]),
+    ).not.toThrow();
+  });
+
+  it('reports "expected a JSON array" only when the root value is not an array', () => {
+    expect(() => validateTestCaseInputArray({})).toThrow(
+      'Invalid JSON structure. Expected a JSON array.',
+    );
+    expect(() => validateTestCaseInputArray('not an array')).toThrow(
+      'Invalid JSON structure. Expected a JSON array.',
+    );
+  });
+
+  it('does not use the array-shape message for a problem inside one element', () => {
+    // A real array, but item 0 is missing `question` -- not an array-shape problem.
+    expect(() =>
+      validateTestCaseInputArray([{ expectedOutcome: minimalCase.expectedOutcome }]),
+    ).toThrow(/index 0/);
+  });
+});

--- a/src/schemas/test-case.ts
+++ b/src/schemas/test-case.ts
@@ -9,7 +9,11 @@ export const testCaseChatHistorySchema = z.object({
 });
 
 export const testCaseInputSchema = z.object({
-  id: z.string(),
+  // Optional here (unlike testCaseSchema below): initialTestCases/import accept
+  // the minimal { question, expectedOutcome } shape documented in the README,
+  // with id filled in by createTestCaseFromInput. A fully-formed runtime
+  // TestCase always has one -- see testCaseSchema.
+  id: z.string().optional(),
   question: z.string(),
   expectedOutcome: expectedOutcomeArraySchema,
   chatHistory: testCaseChatHistorySchema.optional(),
@@ -48,10 +52,15 @@ export function validateTestCaseInputArray(
   const parsed = testCaseInputArraySchema.safeParse(data);
   if (!parsed.success) {
     const firstIssue = parsed.error.issues[0];
+    // path.length === 0 means the issue is about `data` itself (e.g. it's an
+    // object, not an array) -- that's the only case "expected a JSON array" is
+    // actually correct. A non-empty path means the issue is about a field
+    // inside one element (e.g. `expectedOutcome` on item 0), which the generic
+    // top-level message would misreport as an array-shape problem.
     const message =
-      firstIssue.code === 'invalid_type'
+      firstIssue.code === 'invalid_type' && firstIssue.path.length === 0
         ? 'Invalid JSON structure. Expected a JSON array.'
-        : firstIssue.message;
+        : `Invalid test case at index ${String(firstIssue.path[0] ?? '?')}: ${firstIssue.message} (${firstIssue.path.slice(1).map(String).join('.') || 'root'})`;
     throw new Error(message);
   }
 }


### PR DESCRIPTION
## Summary
`initialTestCases`/import accepting `{ question, expectedOutcome }` with no `id` is explicitly documented in the README ("The runner will fill in `id`..."), but that was never actually true:

- `testCaseInputSchema.id` was required (`z.string()`, no `.optional()`)
- `createTestCaseFromInput` — the only place that could fill in a missing `id` — just spread the input through unchanged, generating nothing
- So the documented minimal shape failed Zod validation in `componentWillLoad()` before it ever reached the factory

On top of that, the resulting error was actively misleading: `validateTestCaseInputArray` mapped **any** `invalid_type` Zod issue to `"Invalid JSON structure. Expected a JSON array."`, regardless of whether the problem was the root value not being an array, or a single field on one nested element. A missing `id` on test case 0 and a genuinely non-array root produced the identical, wrong-for-one-of-them message — very hard to debug from the message alone.

## Changes
- `testCaseInputSchema.id` is now optional, matching the README.
- `createTestCaseFromInput` generates `crypto.randomUUID()` when `id` is omitted, so it actually does what its own docstring already claimed.
- `validateTestCaseInputArray` only shows the array-shape message when the failing issue's `path` is empty (i.e. it's really about the root value); otherwise it reports which test case index and field actually failed.
- New `src/schemas/test-case.spec.ts` covering both validators.

Found integrating `llm-testrunner-components` into an external app's Vitest+React setup, where `initialTestCases` with the documented minimal shape threw this on the very first load.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 246 passed (241 existing + 5 new), no regressions
- [x] `npm run lint` — no new warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)