### PR TITLE
Add Claude Code Review workflow for automated PR review

### DIFF
--- a/.github/workflows/claude-code-re-review.yml
+++ b/.github/workflows/claude-code-re-review.yml
@@ -15,9 +15,14 @@ jobs:
     # this job (and its "skipped" check) still appears for any PR comment that
     # doesn't match -- including the bot's own posted comments -- just cheaply
     # and near-instantly, without ever starting a runner.
+    # author_association gate matters here specifically because this repo is
+    # public: without it, any GitHub account (not just org members) could
+    # comment "@claude re-review" on any PR and trigger a paid, secret-backed,
+    # pull-requests:write invocation, repeatedly, at will.
     if: |
       github.event.issue.pull_request != null &&
-      contains(github.event.comment.body, '@claude re-review')
+      contains(github.event.comment.body, '@claude re-review') &&
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,7 +47,7 @@ jobs:
             This is a SCOPED RE-REVIEW, not a full review. Your job is to verify fixes only.
 
             Steps:
-            1. Fetch all previous comments on this PR using `gh pr view $PR_NUMBER --comments` and `gh api repos/$REPO/issues/$PR_NUMBER/comments`.
+            1. Fetch all previous comments on this PR using `gh pr view $PR_NUMBER --comments` and `gh api repos/$REPO/issues/$PR_NUMBER/comments` (GET only -- do not pass -X/--method).
             2. Identify every issue you (Claude / github-actions[bot]) flagged in prior review comments.
             3. For each previously flagged issue, check the current diff (`gh pr diff $PR_NUMBER`) and determine:
                - FIXED: the issue is resolved
@@ -67,4 +72,13 @@ jobs:
 
             Use `gh pr comment` with your Bash tool to post the result on the PR.
 
-          claude_args: '--model claude-sonnet-5 --allowed-tools "Bash(gh issue view:*),Bash(gh api:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'
+          # gh api is scoped to the one read-only endpoint the prompt above
+          # actually uses (repos/*/issues/*/comments), not the full API --
+          # this agent reads attacker-controllable PR comment text, so a
+          # prompt-injected instruction to hit an unrelated, mutating
+          # endpoint shouldn't be reachable via an over-broad allowlist. This
+          # narrows blast radius; it isn't a hard guarantee against every
+          # possible injected argument on that same endpoint (e.g. -X DELETE),
+          # since Claude Code's tool-allow patterns match by command prefix,
+          # not by HTTP method.
+          claude_args: '--model claude-sonnet-5 --allowed-tools "Bash(gh issue view:*),Bash(gh api repos/*/issues/*/comments),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'

--- a/.github/workflows/claude-code-re-review.yml
+++ b/.github/workflows/claude-code-re-review.yml
@@ -1,0 +1,70 @@
+name: Claude Code Re-Review
+
+# Separate workflow file from claude-code-review.yml deliberately -- a single
+# workflow listening for both pull_request and issue_comment would spin up both
+# jobs on every event and show the non-applicable one as a permanent "skipped"
+# check on every PR, even ones nobody ever comments "@claude re-review" on.
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude-re-review:
+    # Scoped re-review: fires when someone comments "@claude re-review" on a PR.
+    # GitHub can't filter issue_comment events by body before creating a run, so
+    # this job (and its "skipped" check) still appears for any PR comment that
+    # doesn't match -- including the bot's own posted comments -- just cheaply
+    # and near-instantly, without ever starting a runner.
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude re-review')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Scoped Re-Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_CODE_REVIEW_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.issue.number }}
+
+            This is a SCOPED RE-REVIEW, not a full review. Your job is to verify fixes only.
+
+            Steps:
+            1. Fetch all previous comments on this PR using `gh pr view $PR_NUMBER --comments` and `gh api repos/$REPO/issues/$PR_NUMBER/comments`.
+            2. Identify every issue you (Claude / github-actions[bot]) flagged in prior review comments.
+            3. For each previously flagged issue, check the current diff (`gh pr diff $PR_NUMBER`) and determine:
+               - FIXED: the issue is resolved
+               - STILL PRESENT: the issue was not addressed
+               - REGRESSION: a fix introduced a new problem in this area
+            4. Report ONLY on those prior issues -- do not introduce new findings.
+
+            Format your response exactly like this:
+
+            ## 🔍 Re-Review Results
+
+            | Status | Issue |
+            |--------|-------|
+            | ✅ Fixed | Brief description |
+            | ❌ Still present | Brief description |
+            | ⚠️ Regression | Brief description |
+
+            Then add a one-line summary at the bottom, e.g.:
+            **All X issues fixed. No regressions observed.** or **X/Y issues fixed -- N still need attention.**
+
+            Keep each row concise (one line). Do not write paragraphs.
+
+            Use `gh pr comment` with your Bash tool to post the result on the PR.
+
+          claude_args: '--model claude-sonnet-5 --allowed-tools "Bash(gh issue view:*),Bash(gh api:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,58 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+
+jobs:
+  claude-review:
+    # Auto-review: fires only when PR is first opened (not on every push) --
+    # avoids the /code-review plugin's "already reviewed" gate entirely by not
+    # attempting an automatic re-review in the first place. Re-reviews are
+    # instead scoped and on-demand, via claude-code-re-review.yml.
+    # Also skips fork PRs, which would fail anyway since GitHub doesn't expose
+    # repo secrets (including ANTHROPIC_CODE_REVIEW_KEY) to pull_request-triggered
+    # workflows on fork PRs.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_CODE_REVIEW_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: '--model claude-sonnet-5 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,10 +46,11 @@ consumer, in ways this repo's tests structurally cannot catch:
 ## Build has three separate stages, each backing a different published entry point
 
 `npm run build` = `stencil build && tsc --project tsconfig.react.json && tsup`.
-Each stage owns a different subpath in `package.json`'s `exports` map:
-Stencil → `.`/`./loader` (the web components + lazy-loading proxy), the
-`tsc` step → `./react` (the generated React wrapper + its types), `tsup` →
-`./headless` (the framework-free Jest-matchers module). Running just
+Each stage produces build artifacts backing a different published subpath —
+there's no bare `.` entry in `package.json`'s `exports` map, only subpaths:
+Stencil → `./loader` and `./dist/*` (the web components + lazy-loading
+proxy), the `tsc` step → `./react` (the generated React wrapper + its types),
+`tsup` → `./headless` (the framework-free Jest-matchers module). Running just
 `stencil build` (e.g. via the Stencil CLI directly, out of habit) silently
 leaves `./react` and `./headless` stale — always use `npm run build` (or
 `build:all`, which also runs `build:react` again) when verifying a change

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# Agent notes for this repo
+
+Practical, hard-won guidance for AI coding agents (Claude Code, Cursor, etc.)
+working in this repo — not a restatement of [README.md](README.md) (what the
+library does), [CONTRIBUTING.md](CONTRIBUTING.md) (PR process basics), or
+[RELEASING.md](RELEASING.md) (the release flow — read that directly, don't
+duplicate it here). This is about *how things actually go wrong here*.
+
+Last verified 2026-09-08 — re-check environment-specific claims below if it's
+been a while.
+
+## This is a published library — passing tests here is not enough
+
+`llm-testrunner-components` ships to npm and gets consumed by external apps.
+A change that passes this repo's own `npm test` can still be broken for every
+consumer, in ways this repo's tests structurally cannot catch:
+
+- **A schema fix and its public TypeScript type must move together.**
+  `src/schemas/*.ts` (runtime Zod validation) and the `@Prop()` declarations in
+  `src/components/llm-test-runner/llm-test-runner.tsx` are two separate
+  sources of truth for the same public API surface. Loosening a Zod schema
+  (e.g. making a field optional) does nothing for a TypeScript consumer if the
+  `@Prop()` is still typed against the stricter shape (e.g. `TestCase[]`
+  instead of `TestCaseInput[]`) — this exact bug shipped and was only caught
+  by an external consumer's `tsc`, not by anything in this repo. Jest tests
+  run against already-transpiled JS and don't type-check consumer call sites,
+  so this class of bug is invisible to `npm test` no matter how much coverage
+  you add here.
+- **Before considering a public-API change done, verify it against a real
+  external consumer**, not just this repo's suite:
+  ```bash
+  npm run build && npm pack   # produces llm-testrunner-components-X.Y.Z.tgz
+  ```
+  Install that tarball in a real consuming app (`npm install /path/to/*.tgz`)
+  and check both runtime behavior *and* `tsc --noEmit` there. If the consumer
+  runs in Docker with its own `node_modules` (as with one known internal
+  consumer), a host-side `npm install` doesn't reach the container — copy the
+  tarball in and install it inside the container instead:
+  ```bash
+  docker compose cp llm-testrunner-components-X.Y.Z.tgz <service>:/tmp/pkg.tgz
+  docker compose exec <service> npm install /tmp/pkg.tgz
+  ```
+  Restart/recreate the consumer's dev server after — bundlers cache dependency
+  metadata and won't pick up a swapped local package without one.
+
+## Build has three separate stages, each backing a different published entry point
+
+`npm run build` = `stencil build && tsc --project tsconfig.react.json && tsup`.
+Each stage owns a different subpath in `package.json`'s `exports` map:
+Stencil → `.`/`./loader` (the web components + lazy-loading proxy), the
+`tsc` step → `./react` (the generated React wrapper + its types), `tsup` →
+`./headless` (the framework-free Jest-matchers module). Running just
+`stencil build` (e.g. via the Stencil CLI directly, out of habit) silently
+leaves `./react` and `./headless` stale — always use `npm run build` (or
+`build:all`, which also runs `build:react` again) when verifying a change
+that touches any of the three.
+
+## Known consumer-side gotcha worth knowing about (not fixable here)
+
+A Vite-based consumer app will hard-crash its entire dev server (not just
+warn) the first time it imports this package, with an error like
+`No loader is configured for ".map" files: .../dist/esm/*.entry.js.map`.
+Cause: Stencil's lazy component loader does a dynamic
+`` import(`./${bundleId}.entry.js`) ``, and Vite's esbuild-based dependency
+scanner statically over-scans the whole directory that pattern could match,
+including sibling `.map` sourcemap files it has no loader for. This is a
+Vite/esbuild + Stencil interaction, not something to fix in this repo — the
+consumer needs `optimizeDeps: { exclude: ['llm-testrunner-components'] }` in
+their `vite.config.ts`. Worth mentioning proactively if you're ever helping
+someone integrate this package into a Vite app and they hit a dev-server
+crash on the very first import.
+
+## PR review workflow
+
+Same setup as `FluxonApps/llm-testrunner` (`.github/workflows/claude-code-review.yml`
++ `claude-code-re-review.yml`):
+
+- **A PR that modifies its own review workflow file can never be reviewed by
+  that workflow** — GitHub blocks this by design (a security measure, not a
+  bug: `Workflow validation failed: the workflow file must exist and have
+  identical content to the version on the default branch`). Normal; it starts
+  working once merged.
+- **`claude-review` only fires on `pull_request: opened`**, not later pushes —
+  deliberate, to avoid the `/code-review` plugin's known "already reviewed,
+  skip" no-op bug. Comment `@claude re-review` on a PR to get a scoped
+  re-check (fixed/still-present/regression against previously-flagged issues)
+  instead of expecting automatic re-review on every push.
+- Merging needs an actual human-approving review — a bot comment alone
+  doesn't satisfy branch protection.


### PR DESCRIPTION
## Summary
Ports the same Claude Code Review setup from FluxonApps/llm-testrunner (#151, #153) to this repo, so PRs raised here (like #104) get the same automated review. Also adds `AGENTS.md`.

### Claude Code Review
- `claude-code-review.yml` — reviews once when a PR is opened, posts a PR comment.
- `claude-code-re-review.yml` — separate workflow, fires only when someone comments `@claude re-review` on a PR; does a scoped check of previously-flagged issues (fixed/still-present/regression), not a full re-review.

Kept as two separate workflow files rather than one combined file with both triggers — a combined file means every `pull_request` event also spins up the re-review job (which self-skips based on event type), and that shows as a permanent "skipped" check on every single PR regardless of whether anyone ever comments. Splitting avoids that.

`ANTHROPIC_CODE_REVIEW_KEY` secret already exists on this repo (added in preparation for this).

### AGENTS.md
Tool-agnostic (Claude Code and Cursor both read it natively). Covers what's specific to this repo and not already in README/CONTRIBUTING/RELEASING:
- This is a published library — this repo's own tests passing doesn't prove a public-API change works for consumers. The `initialTestCases`/`TestCase`-vs-`TestCaseInput` type bug from #104 is the concrete example: a runtime schema fix alone left the public `@Prop()` type still too strict, caught only by an external consumer's `tsc`, invisible to this repo's Jest suite.
- The three-stage build (`stencil build && tsc --project tsconfig.react.json && tsup`) backs three separate published entry points (`.`, `./react`, `./headless`) — running just one stage silently leaves the others stale.
- A known Vite/esbuild + Stencil lazy-loader interaction that crashes a consumer's dev server on first import (`optimizeDeps.exclude` is the fix, on the consumer's side).
- Same PR-review-workflow notes as `llm-testrunner`'s `AGENTS.md`.

## Note
This PR itself can't be reviewed by the workflow it introduces — GitHub blocks a PR from running a real instance of a workflow it's modifying (security measure against a PR rewriting its own review workflow to exfiltrate secrets). Expected; it'll start working on the next PR opened after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)